### PR TITLE
Management console optional certbot configuration

### DIFF
--- a/roles/console/defaults/main.yml
+++ b/roles/console/defaults/main.yml
@@ -1,5 +1,12 @@
 ---
+# Console
 eucaconsole_product: "{{ eucalyptus_product }}"
 eucaconsole_ats_product_url: https://www.appscale.com/product/
 eucaconsole_firewalld_configure: yes
+eucaconsole_domain: "console.{{ cloud_system_dns_dnsdomain | default('localhost') }}"
 eucaconsole_admin_password: ""
+
+# Certbot
+eucaconsole_certbot_configure: no
+eucaconsole_certbot_email: ""
+eucaconsole_certbot_certonly_opts: "--no-eff-email"

--- a/roles/console/files/certbot-renew-eucaconsole.conf
+++ b/roles/console/files/certbot-renew-eucaconsole.conf
@@ -1,0 +1,3 @@
+[Service]
+EnvironmentFile=
+Environment="DEPLOY_HOOK=--deploy-hook /usr/bin/eucaconsole-reload-https" "CERTBOT_ARGS=--cert-name eucaconsole"

--- a/roles/console/tasks/certbot.yml
+++ b/roles/console/tasks/certbot.yml
@@ -1,0 +1,54 @@
+---
+# Provision and renew letsencrypt https certificate using certbot
+
+- name: install certbot package
+  yum:
+    name: certbot
+    state: present
+  tags:
+    - packages
+
+- name: certbot-renew service.d directory
+  file:
+    path: /etc/systemd/system/certbot-renew.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: eucaconsole certbot-renew configuration drop-in
+  copy:
+    src: certbot-renew-eucaconsole.conf
+    dest: /etc/systemd/system/certbot-renew.service.d/certbot-renew-eucaconsole.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: eucaconsole certbot https
+  shell: |
+    set -eu
+    CONSOLE_DOMAIN={{ eucaconsole_domain | quote }}
+    REGISTRATION_EMAIL={{ eucaconsole_certbot_email | quote }}
+    EXTRA_OPTS={{ eucaconsole_certbot_certonly_opts | quote }}
+    if [ -z "${REGISTRATION_EMAIL}" ] ; then
+      EXTRA_OPTS="${EXTRA_OPTS} --register-unsafely-without-email"
+    else
+      EXTRA_OPTS="${EXTRA_OPTS} --email ${REGISTRATION_EMAIL}"
+    fi
+    certbot certonly \
+      --non-interactive \
+      --agree-tos \
+      --cert-name eucaconsole \
+      --domain "${CONSOLE_DOMAIN}" \
+      --webroot \
+      --webroot-path /var/lib/eucaconsole/well-known-root/ \
+      ${EXTRA_OPTS}
+    ln -s -f -T /etc/letsencrypt/live/eucaconsole/fullchain.pem /etc/pki/tls/certs/eucaconsole.crt
+    ln -s -f -T /etc/letsencrypt/live/eucaconsole/privkey.pem /etc/pki/tls/private/eucaconsole.key
+    eucaconsole-reload-https
+
+- name: eucaconsole certbot https renewal
+  systemd:
+    enabled: true
+    state: started
+    name: certbot-renew.timer

--- a/roles/console/tasks/main.yml
+++ b/roles/console/tasks/main.yml
@@ -80,3 +80,6 @@
   failed_when:
     - shell_result.rc != 0
     - '"EntityAlreadyExists" not in shell_result.stderr'
+
+- import_tasks: certbot.yml
+  when: eucaconsole_certbot_configure


### PR DESCRIPTION
Add tasks to configure certbot for automated lets encrypt https certificate issue and renewal.

For automated provisioning the deployment must be reachable from the internet and `eucaconsole_certbot_configure` must be `yes`. The optional `eucaconsole_certbot_email` can be set to specify a recipient for any lets encrypt emails.