### PR TITLE
Management console certbot support for service domains / services https

### DIFF
--- a/roles/cloud/files/eucalyptus-cloud-https-import
+++ b/roles/cloud/files/eucalyptus-cloud-https-import
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Import HTTPS key/certificate from PEM files
+set -eo pipefail
+
+KEY_ALIAS="eucaconsole"
+PEM_KEY="/etc/pki/tls/private/eucaconsole.key"
+PEM_CERTS="/etc/pki/tls/certs/eucaconsole.crt"
+
+while (( "$#" )); do
+  IMPORT_ARG="$1"
+  case "${IMPORT_ARG}" in
+    --alias)
+      shift
+      KEY_ALIAS="$1"
+      ;;
+    --key)
+      shift
+      PEM_KEY="$1"
+      ;;
+    --certs)
+      shift
+      PEM_CERTS="$1"
+      ;;
+    *)
+      echo -e "Usage:\n\n\teucalyptus-cloud-https-import [--alias ALIAS] [--key FILE] [--certs FILE]\n"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ ! -f "${PEM_KEY}" ] ; then
+  echo "Not found: ${PEM_KEY}"
+  exit 1
+fi
+if [ ! -f "${PEM_CERTS}" ] ; then
+  echo "Not found: ${PEM_CERTS}"
+  exit 1
+fi
+
+PEM_KEY_VALUE="$(<$PEM_KEY)"
+PEM_CERTS_VALUE="$(<$PEM_CERTS)"
+
+cat << SCRIPT |
+import com.eucalyptus.component.auth.SystemCredentials
+import com.eucalyptus.crypto.util.PEMFiles
+import java.security.cert.X509Certificate
+import java.security.KeyPair
+import java.nio.charset.StandardCharsets
+
+// wildcards hostname
+String keypairPem          = """$PEM_KEY_VALUE"""
+String certificateChainPem = """$PEM_CERTS_VALUE"""
+String keyAlias            = """$KEY_ALIAS"""
+
+// handle pem
+KeyPair keyPair = PEMFiles.getKeyPair( keypairPem.getBytes( StandardCharsets.UTF_8 ) )
+X509Certificate[] certificates = PEMFiles.getCertChain( certificateChainPem.getBytes( StandardCharsets.UTF_8 ) )
+
+// import key and certificate chain
+SystemCredentials.keyStore.addKeyPair( keyAlias, certificates, keyPair.getPrivate( ), '' )
+
+// result
+"To use imported certificate, run:\n\n\teuctl bootstrap.webservices.ssl.server_alias=\${keyAlias}\n"
+SCRIPT
+euctl euca=@/dev/stdin

--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -224,6 +224,14 @@
     - shell_result.rc != 0
     - '"is already registered." not in shell_result.stderr'
 
+- name: eucalyptus cloud services https import utility
+  copy:
+    src: eucalyptus-cloud-https-import
+    dest: /usr/local/bin/eucalyptus-cloud-https-import
+    owner: root
+    group: root
+    mode: 0755
+
 - name: tools configuration directory
   file:
     path: /root/.euca

--- a/roles/console/defaults/main.yml
+++ b/roles/console/defaults/main.yml
@@ -3,10 +3,12 @@
 eucaconsole_product: "{{ eucalyptus_product }}"
 eucaconsole_ats_product_url: https://www.appscale.com/product/
 eucaconsole_firewalld_configure: yes
-eucaconsole_domain: "console.{{ cloud_system_dns_dnsdomain | default('localhost') }}"
 eucaconsole_admin_password: ""
 
 # Certbot
 eucaconsole_certbot_configure: no
+eucaconsole_certbot_domain: "console.{{ cloud_system_dns_dnsdomain | default('localhost') }}"
 eucaconsole_certbot_email: ""
 eucaconsole_certbot_certonly_opts: "--no-eff-email"
+eucaconsole_certbot_request_service_domains: yes
+eucaconsole_certbot_services: [autoscaling, bootstrap, cloudformation, ec2, elasticloadbalancing, iam, monitoring, properties, s3, sqs, sts, swf]

--- a/roles/console/files/certbot-renew-eucaconsole.conf
+++ b/roles/console/files/certbot-renew-eucaconsole.conf
@@ -1,3 +1,3 @@
 [Service]
 EnvironmentFile=
-Environment="DEPLOY_HOOK=--deploy-hook /usr/bin/eucaconsole-reload-https" "CERTBOT_ARGS=--cert-name eucaconsole"
+Environment="DEPLOY_HOOK=--deploy-hook /usr/bin/eucaconsole-reload-https --deploy-hook /usr/local/bin/eucalyptus-cloud-https-import" "CERTBOT_ARGS=--cert-name eucaconsole"

--- a/roles/console/tasks/certbot.yml
+++ b/roles/console/tasks/certbot.yml
@@ -24,10 +24,15 @@
     group: root
     mode: 0644
 
+- name: certbot configuration to issue for service endpoints
+  set_fact:
+    eucaconsole_certbot_domain: "{{ eucaconsole_certbot_domain }},{{ eucaconsole_certbot_services | map('regex_replace', '^(.*)$', '\\1.' + cloud_system_dns_dnsdomain) | list | unique | sort | join(',') }}"
+  when: eucaconsole_certbot_request_service_domains and cloud_system_dns_dnsdomain
+
 - name: eucaconsole certbot https
   shell: |
     set -eu
-    CONSOLE_DOMAIN={{ eucaconsole_domain | quote }}
+    CONSOLE_DOMAIN={{ eucaconsole_certbot_domain | quote }}
     REGISTRATION_EMAIL={{ eucaconsole_certbot_email | quote }}
     EXTRA_OPTS={{ eucaconsole_certbot_certonly_opts | quote }}
     if [ -z "${REGISTRATION_EMAIL}" ] ; then
@@ -46,9 +51,18 @@
     ln -s -f -T /etc/letsencrypt/live/eucaconsole/fullchain.pem /etc/pki/tls/certs/eucaconsole.crt
     ln -s -f -T /etc/letsencrypt/live/eucaconsole/privkey.pem /etc/pki/tls/private/eucaconsole.key
     eucaconsole-reload-https
+    eucalyptus-cloud-https-import
 
 - name: eucaconsole certbot https renewal
   systemd:
     enabled: true
     state: started
     name: certbot-renew.timer
+
+- name: configure cloud property for services https
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euctl euctl bootstrap.webservices.ssl.server_alias=eucaconsole
+  delegate_to: "{{ groups.cloud[0] }}"
+  when: eucaconsole_certbot_request_service_domains and cloud_system_dns_dnsdomain


### PR DESCRIPTION
Management console certbot configuration update to allow issuing a certificate that includes domains for web service endpoints. The issued certificate is then also imported for web services and enabled (by alias)

This optional behaviour can be disabled by setting `eucaconsole_certbot_request_service_domains` to `no`. The domains requested can be customized by updating `eucaconsole_certbot_domain` and/or `eucaconsole_certbot_services`.