### PR TITLE
Retry service image install

### DIFF
--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -223,6 +223,8 @@
   failed_when:
     - shell_result.rc != 0
     - '"is already registered." not in shell_result.stderr'
+  until: shell_result is succeeded
+  retries: 5
 
 - name: eucalyptus cloud services https import utility
   copy:


### PR DESCRIPTION
Service image installation can sometimes fail due to s3 not yet being available. We now retry the service image install to allow s3 time to start.