### PR TITLE
Update selinux tags to allow skip where selinux is disabled

### DIFF
--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -110,6 +110,7 @@
     state: yes
   tags:
     - image
+    - selinux
   when: net_mode == "VPCMIDO"
 
 - name: eucalyptus network yaml

--- a/roles/common/tasks/base_config.yml
+++ b/roles/common/tasks/base_config.yml
@@ -5,6 +5,7 @@
     state: permissive
   tags:
     - image
+    - selinux
 
 - name: install eucalyptus package
   yum:

--- a/roles/zone/tasks/main.yml
+++ b/roles/zone/tasks/main.yml
@@ -22,7 +22,7 @@
     persistent: yes
   tags:
     - image
-    - packages
+    - selinux
 
 - name: eucalyptus ceph configuration
   copy:


### PR DESCRIPTION
Installs can fail when selinux is disabled and related plays are run. We now have `selinux` tags on this functionality so the playbook can be successfully run with `--skip-tags selinux`.