### PR TITLE
Ceph additional options for use of existing deployment

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -7,6 +7,12 @@ ceph_cluster_network: "{{ ceph_public_network }}"
 
 ceph_osd_data_path: /var/lib/ceph-osd/osd0
 
+ceph_osd_volume_pool: eucavolumes
+
+ceph_osd_snapshot_pool: eucasnapshots
+
+ceph_rgw_uid: eucas3
+
 ceph_facts: "{{ True if ('ceph' in groups and groups['ceph']) else False }}"
 
 cloud_firewalld_configure: no

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -13,7 +13,13 @@ ceph_osd_snapshot_pool: eucasnapshots
 
 ceph_rgw_uid: eucas3
 
-ceph_facts: "{{ True if ('ceph' in groups and groups['ceph']) else False }}"
+ceph_facts: "{{ True if (ceph_facts_local or ('ceph' in groups and groups['ceph'])) else False }}"
+
+ceph_facts_local: no
+
+ceph_facts_delegate: "{{ 'localhost' if ceph_facts_local else None }}"
+
+ceph_facts_path: /root/eucalyptus/ceph
 
 cloud_firewalld_configure: no
 

--- a/roles/ceph-common/tasks/ceph_facts.yml
+++ b/roles/ceph-common/tasks/ceph_facts.yml
@@ -1,6 +1,6 @@
 - name: eucalyptus gather ceph configuration
   slurp:
-    path: /root/eucalyptus/ceph/ceph.conf
+    path: "{{ ceph_facts_path }}/ceph.conf"
   register: slurp_result
 
 - name: set eucalyptus ceph configuration fact
@@ -9,7 +9,7 @@
 
 - name: eucalyptus gather ceph client keyring
   slurp:
-    path: /root/eucalyptus/ceph/ceph.client.eucalyptus.keyring
+    path: "{{ ceph_facts_path }}/ceph.client.eucalyptus.keyring"
   register: slurp_result
 
 - name: set eucalyptus ceph client keyring fact
@@ -18,14 +18,20 @@
 
 - name: eucalyptus gather ceph radosgw s3 credentials
   slurp:
-    path: /root/eucalyptus/ceph/rgw_credentials.json
+    path: "{{ ceph_facts_path }}/rgw_credentials.json"
   register: slurp_result
 
 - name: set eucalyptus ceph radosgw s3 credentials fact
   set_fact:
     eucalyptus_ceph_rgw_creds: "{{ slurp_result.content | b64decode | from_json }}"
 
+- name: set eucalyptus ceph radosgw s3 endpoint local fact
+  set_fact:
+    eucalyptus_ceph_rgw_endpoint: "{{ eucalyptus_ceph_rgw_host }}:7480"
+  when: eucalyptus_ceph_rgw_host is defined
+
 - name: set eucalyptus ceph radosgw s3 endpoint fact
   set_fact:
     eucalyptus_ceph_rgw_endpoint: "{{ hostvars[groups['ceph_object_gateway'][0]]['eucalyptus_host_cluster_ipv4'] }}:7480"
+  when: eucalyptus_ceph_rgw_host is not defined
 

--- a/roles/ceph-common/tasks/main.yml
+++ b/roles/ceph-common/tasks/main.yml
@@ -11,6 +11,6 @@
   when: cloud_firewalld_configure
 
 - import_tasks: ceph_facts.yml
-  delegate_to: "{{ groups['ceph_deploy'][0] }}"
+  delegate_to: "{{ ceph_facts_delegate|default(groups['ceph_deploy'][0], true) }}"
   run_once: yes
   when: ceph_facts

--- a/roles/ceph/files/ceph-euca-setup.sh
+++ b/roles/ceph/files/ceph-euca-setup.sh
@@ -5,14 +5,22 @@ set -euo pipefail
 
 EUCA_POOL_PLACEMENT_GROUPS="${EUCA_POOL_PLACEMENT_GROUPS:-100}"
 EUCA_CEPH_ARTIFACTS_DIR="${EUCA_CEPH_ARTIFACTS_DIR:-euca-artifacts}"
+EUCA_CEPH_VOLUME_POOL_NAME="${EUCA_CEPH_VOLUME_POOL_NAME:-eucavolumes}"
+EUCA_CEPH_SNAPSHOT_POOL_NAME="${EUCA_CEPH_SNAPSHOT_POOL_NAME:-eucasnapshots}"
+EUCA_CEPHRGW_UID="${EUCA_CEPHRGW_UID:-eucas3}"
 
-if ! ceph osd pool ls | grep -q euca ; then
-    echo "Generating volume and snapshot pools"
-    ceph osd pool create eucavolumes ${EUCA_POOL_PLACEMENT_GROUPS}
-    ceph osd pool application enable eucavolumes rbd 2>/dev/null || true
+if ! ceph osd pool ls | grep -q ${EUCA_CEPH_VOLUME_POOL_NAME} ; then
+    echo "Generating volume pool ${EUCA_CEPH_VOLUME_POOL_NAME}"
+    ceph osd pool create ${EUCA_CEPH_VOLUME_POOL_NAME} ${EUCA_POOL_PLACEMENT_GROUPS}
+    ceph osd pool application enable ${EUCA_CEPH_VOLUME_POOL_NAME} rbd 2>/dev/null || true
+fi
 
-    ceph osd pool create eucasnapshots ${EUCA_POOL_PLACEMENT_GROUPS}
-    ceph osd pool application enable eucasnapshots rbd 2>/dev/null || true
+if [ "${EUCA_CEPH_VOLUME_POOL_NAME}" != "${EUCA_CEPH_SNAPSHOT_POOL_NAME}" ] ; then
+    if ! ceph osd pool ls | grep -q ${EUCA_CEPH_SNAPSHOT_POOL_NAME} ; then
+        echo "Generating snapshot pool ${EUCA_CEPH_SNAPSHOT_POOL_NAME}"
+        ceph osd pool create ${EUCA_CEPH_SNAPSHOT_POOL_NAME} ${EUCA_POOL_PLACEMENT_GROUPS}
+        ceph osd pool application enable ${EUCA_CEPH_SNAPSHOT_POOL_NAME} rbd 2>/dev/null || true
+    fi
 fi
 
 if [ ! -e "${EUCA_CEPH_ARTIFACTS_DIR}" ] ; then
@@ -24,13 +32,13 @@ if ! ceph auth list 2>&1 | grep -q euca ; then
     echo "Generating S3 user for radosgw"
     ceph auth get-or-create client.eucalyptus \
       mon 'allow r' \
-      osd 'allow rwx pool=rbd, allow rwx pool=eucasnapshots, allow rwx pool=eucavolumes, allow x' \
+      osd 'allow rwx pool=rbd, allow rwx pool='${EUCA_CEPH_SNAPSHOT_POOL_NAME}', allow rwx pool='${EUCA_CEPH_VOLUME_POOL_NAME}', allow x' \
       -o "${EUCA_CEPH_ARTIFACTS_DIR}/ceph.client.eucalyptus.keyring"
 fi
 
 if ! radosgw-admin metadata list user | grep -q euca ; then
     echo "Generating radowsgw (rgw) S3 user"
-    radosgw-admin user create --uid=eucas3 --display-name="Eucalyptus S3 User" \
+    radosgw-admin user create --uid=${EUCA_CEPHRGW_UID} --display-name="Eucalyptus S3 User" \
       | egrep '(user"|access_key|secret_key)' \
       | sed --expression='1 i\{' --expression='$ a\}' \
       > "${EUCA_CEPH_ARTIFACTS_DIR}/rgw_credentials.json"

--- a/roles/ceph/tasks/ceph_eucalyptus.yml
+++ b/roles/ceph/tasks/ceph_eucalyptus.yml
@@ -14,5 +14,8 @@
     creates: /root/eucalyptus/ceph/ceph.conf
   environment:
     EUCA_CEPH_ARTIFACTS_DIR: /root/eucalyptus/ceph
+    EUCA_CEPH_RGW_UID: "{{ ceph_rgw_uid }}"
+    EUCA_CEPH_SNAPSHOT_POOL_NAME: "{{ ceph_osd_snapshot_pool }}"
+    EUCA_CEPH_VOLUME_POOL_NAME: "{{ ceph_osd_volume_pool }}"
     EUCA_POOL_PLACEMENT_GROUPS: 60
 

--- a/roles/zone/tasks/main.yml
+++ b/roles/zone/tasks/main.yml
@@ -75,9 +75,11 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
+    CEPH_SNAPSHOT_POOL={{ ceph_osd_snapshot_pool | quote }}
+    CEPH_VOLUME_POOL={{ ceph_osd_volume_pool | quote }}
     ZONE_NAME={{ eucalyptus_zone_name | quote }}
-    euctl ${ZONE_NAME}.storage.cephsnapshotpools=eucasnapshots
-    euctl ${ZONE_NAME}.storage.cephvolumepools=eucavolumes
+    euctl ${ZONE_NAME}.storage.cephsnapshotpools=${CEPH_SNAPSHOT_POOL}
+    euctl ${ZONE_NAME}.storage.cephvolumepools=${CEPH_VOLUME_POOL}
     euctl ${ZONE_NAME}.storage.blockstoragemanager=ceph-rbd
   delegate_to: "{{ groups.cloud[0] }}"
   when: eucalyptus_ceph_conf is defined


### PR DESCRIPTION
This pull request supports use of an existing ceph/rados gateway when deploying. 

The necessary ceph configuration artifacts must be placed on the host running the ansible playbook and enabled, e.g.:

```
  ceph_facts_local: yes
  ceph_facts_path: /root/
  eucalyptus_ceph_rgw_host: 10.123.10.234
```

where `10.123.10.234` is the rados gateway host. The `ceph_facts_path` path must contain the files:

- ceph.conf
- ceph.client.eucalyptus.keyring
- rgw_credentials.json

Where `ceph.conf` and `ceph.client.eucalyptus.keyring` are as used in the deployment and `rgw_credentials.json` defines settings for objectstorage rados gateway access, e.g.:

```
{
  "user": "eucas3",
  "access_key": "AKI...",
  "secret_key": "m2l..."
}

```

The inventory should not include any ceph hosts and should not use `ceph_converged`.