### PR TITLE
Yum repository configuration options

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -21,19 +21,31 @@
       tasks_from: host_facts
 
 - hosts: midonet_nsdb
+  module_defaults:
+    yum:
+      disablerepo: "{{ eucalyptus_yum_disablerepo | default(omit) }}"
   roles:
   - midonet-nsdb
 
 - hosts: cloud
+  module_defaults:
+    yum:
+      disablerepo: "{{ eucalyptus_yum_disablerepo | default(omit) }}"
   roles:
   - cloud
   - console
 
 - hosts: zone
+  module_defaults:
+    yum:
+      disablerepo: "{{ eucalyptus_yum_disablerepo | default(omit) }}"
   roles:
   - zone
 
 - hosts: node
+  module_defaults:
+    yum:
+      disablerepo: "{{ eucalyptus_yum_disablerepo | default(omit) }}"
   roles:
   - node
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -5,6 +5,8 @@ eucalyptus_yum_baseurl_snapshot: http://downloads.eucalyptus.cloud/software/euca
 eucalyptus_yum_baseurl: "{{ eucalyptus_yum_baseurl_snapshot }}"
 euca2ools_yum_baseurl: http://downloads.eucalyptus.cloud/software/euca2ools/3.4/rhel/7/x86_64/
 eucalyptus_yum_gpgcheck: "1"
+eucalyptus_base_yum_enabled: no
+eucalyptus_base_yum_baseurl: https://downloads.eucalyptus.cloud/software/eucalyptus/base/5/rhel/7/x86_64/
 
 # Product settings
 eucalyptus_product: eucalyptus

--- a/roles/common/tasks/yum_repos.yml
+++ b/roles/common/tasks/yum_repos.yml
@@ -25,6 +25,15 @@
     state: present
     key: /etc/pki/rpm-gpg/RPM-GPG-KEY-eucalyptus-release-as
 
+- name: eucalyptus base yum repository
+  template:
+    src: eucalyptus-base.repo.j2
+    dest: /etc/yum.repos.d/eucalyptus-base.repo
+    owner: root
+    group: root
+    mode: 0644
+  when: eucalyptus_base_yum_enabled|default(False)
+
 - name: eucalyptus yum repository
   template:
     src: eucalyptus.repo.j2

--- a/roles/common/templates/eucalyptus-base.repo.j2
+++ b/roles/common/templates/eucalyptus-base.repo.j2
@@ -1,0 +1,8 @@
+[eucalyptus-base]
+name=Eucalyptus 5 Base - $basearch
+baseurl={{ eucalyptus_base_yum_baseurl }}
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-eucalyptus-release-as
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-eucalyptus-release
+gpgcheck={{ eucalyptus_yum_gpgcheck }}
+enabled=1
+fastestmirror_enabled=0


### PR DESCRIPTION
Updates to yum repository configuration options.

There is a new `eucalyptus_yum_disablerepo` option which can be used to prevent use of some yum repositories during install.

Support is added for a base eucalyptus 5 repository which contains only base rpms that are not created during a typical build. This allows build specific rpms to be installed from a smaller repository. This is expected to be used mainly for development/testing builds.