### PR TITLE
EDGE mode private network/bridge creation for simple deployments

### DIFF
--- a/host_groups.yml
+++ b/host_groups.yml
@@ -61,12 +61,12 @@
     groups: midonet_nsdb
     hostname: "{{ item }}"
     inventory_dir: "{{ hostvars[item].inventory_dir }}"
-  when: ceph_converged|default(False) and net_mode == 'VPCMIDO'
+  when: ceph_converged|default(False) and net_mode|default('EDGE') == 'VPCMIDO'
   with_items: "{{ groups.node }}"
 - name: cloud to midonet_nsdb group for default vpcmido deployments
   add_host:
     groups: midonet_nsdb
     hostname: "{{ item }}"
     inventory_dir: "{{ hostvars[item].inventory_dir }}"
-  when: "'midonet_nsdb' not in groups and net_mode == 'VPCMIDO'"
+  when: "'midonet_nsdb' not in groups and net_mode|default('EDGE') == 'VPCMIDO'"
   with_items: "{{ groups.cloud }}"

--- a/roles/cloud/defaults/main.yml
+++ b/roles/cloud/defaults/main.yml
@@ -5,10 +5,10 @@ cloud_listener_cidr: 0.0.0.0/0
 cloud_properties: {}
 
 # EDGE network settings
-edge_subnet: "{{ ansible_default_ipv4.network }}"
-edge_netmask: "{{ ansible_default_ipv4.netmask }}"
-edge_gateway: "{{ ansible_default_ipv4.gateway }}"
-edge_private_ip_range: 192.168.254.150-192.168.254.199
+edge_subnet: "{{ '172.31.0.0' if edge_bridge_create else ansible_default_ipv4.network }}"
+edge_netmask: "{{ '255.255.0.0' if edge_bridge_create else ansible_default_ipv4.netmask }}"
+edge_gateway: "{{ '172.31.0.1' if edge_bridge_create else ansible_default_ipv4.gateway }}"
+edge_private_ip_range: "{{ '172.31.0.2-172.31.0.254' if edge_bridge_create else '192.168.254.150-192.168.254.199' }}"
 edge_public_ip_range: 192.168.254.200-192.168.254.249
 
 # Firewalld settings

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -51,16 +51,19 @@ cloud_instances_conf_custom: "{{ cloud_instances.conf.custom }}"
 # EDGE network settings
 edge_router_enabled: Y
 edge_router_ip: AUTO
+edge_bridge_create: no
 
 # Network settings
 net_mode: EDGE
 net_mode_lower: "{{ net_mode | lower }}"
 net_mode_:
   edge:
-    bridge_interface: "{{ edge_bridge_interface | default('br0') }}"
+    bridge_interface: "{{ 'euca-priv-br0' if edge_bridge_create else (edge_bridge_interface | default('br0')) }}"
+    private_interface: "{{ 'euca-priv-br0' if edge_bridge_create else (edge_bridge_interface | default('br0')) }}"
   vpcmido:
     bridge_interface: "{{ vpc_bridge_interface | default('br0') }}"
-net_private_interface: "{{ net_public_interface }}"
+    private_interface: "{{ net_public_interface }}"
+net_private_interface: "{{ net_mode_[net_mode_lower]['private_interface'] }}"
 net_public_interface: en1
 net_bridge_interface: "{{ net_mode_[net_mode_lower]['bridge_interface'] }}"
 net_node_listen_addr: "{{ eucalyptus_host_cluster_ipv4 }}"

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -5,3 +5,7 @@ net_mode: EDGE
 # Midonet settings
 midonet_midolman_heap: Null
 
+# EDGE settings
+edge_bridge_create_ip: 172.31.0.1
+edge_bridge_create_prefix: 16
+

--- a/roles/node/tasks/edge.yml
+++ b/roles/node/tasks/edge.yml
@@ -1,0 +1,18 @@
+---
+- name: create edge mode private network bridge service
+  template:
+    src: eucalyptus-edge-brnet.service.j2
+    dest: "/etc/systemd/system/eucalyptus-edge-brnet.service"
+    force: no
+    owner: root
+    group: root
+    mode: 0644
+  when: edge_bridge_create
+
+- name: start edge mode private network bridge service
+  systemd:
+    enabled: true
+    state: started
+    name: eucalyptus-edge-brnet
+  when: edge_bridge_create
+

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -2,6 +2,9 @@
 - import_tasks: vpcmido.yml
   when: net_mode == "VPCMIDO"
 
+- import_tasks: edge.yml
+  when: net_mode == "EDGE"
+
 - name: install eucalyptus-node package
   yum:
     name: eucalyptus-node

--- a/roles/node/templates/eucalyptus-edge-brnet.service.j2
+++ b/roles/node/templates/eucalyptus-edge-brnet.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Eucalyptus Edge Bridge Network
+After=network.target
+Before=eucanetd.service eucalyptus-nc.service
+
+[Service]
+Type=oneshot
+ExecStartPre=-/usr/sbin/ip link add name {{ net_bridge_interface }} type bridge
+ExecStartPre=-/usr/sbin/ip link set dev {{ net_bridge_interface }} up
+ExecStartPre=-/usr/sbin/ip addr add {{ edge_bridge_create_ip }}/{{ edge_bridge_create_prefix }} dev {{ net_bridge_interface }}
+ExecStart=/usr/bin/true
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
EDGE network mode deployments now support creation of a bridge where the private network is available. This is intended to allow small deployments (one node controller) without doing any configuration that would otherwise be needed for the bridge.

To enable bridge creation set:
```
  edge_bridge_create: yes
```
as a variable (e.g. in the inventory), and set the `edge_public_ip_range` and omit any other edge specific network variables.