### PR TITLE
Optionally configure dnsdist for authoritative public dns

### DIFF
--- a/roles/cloud-post/tasks/main.yml
+++ b/roles/cloud-post/tasks/main.yml
@@ -10,3 +10,39 @@
     esi-manage-stack --region localhost -a create imaging
   register: shell_result
   changed_when: '"is already created." not in shell_result.stdout'
+
+- name: configure dns listeners
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euctl --region localhost dns.dns_listener_address_match={{ cloud_dns_listener_address_match | default() | quote }}
+    euctl --region localhost dns.dns_listener_port={{ cloud_dns_listener_port | default(53) | quote }}
+  register: shell_result
+  until: shell_result.rc == 0
+  retries: 5
+  when: cloud_dns_listener_port is defined or cloud_dns_listener_address_match is defined
+
+- name: wait for dns listeners
+  wait_for:
+    sleep: 5
+    host: "{{ eucalyptus_host_public_ipv4 }}"
+    port: "{{ cloud_dns_listener_port | default(53) }}"
+    timeout: 20
+  ignore_errors: yes
+  when: cloud_dns_listener_port is defined or cloud_dns_listener_address_match is defined
+
+- name: configure dnsdist authoritative dns service
+  template:
+    src: dnsdist-eucalyptus.conf.j2
+    dest: /etc/dnsdist/dnsdist-eucalyptus.conf
+    owner: root
+    group: root
+    mode: 0644
+  when: cloud_dns_authoritative_balancer|default(False)
+
+- name: start dnsdist authoritative dns service
+  systemd:
+    enabled: true
+    state: started
+    name: dnsdist@eucalyptus
+  when: cloud_dns_authoritative_balancer|default(False)

--- a/roles/cloud-post/templates/dnsdist-eucalyptus.conf.j2
+++ b/roles/cloud-post/templates/dnsdist-eucalyptus.conf.j2
@@ -1,0 +1,57 @@
+--
+-- Eucalyptus authoritative DNS server configuration for dnsdist
+--
+
+EUCALYPTUS_DNSDOMAIN = "{{ cloud_system_dns_dnsdomain | quote }}"
+
+--
+-- Listener / access control configuration
+--
+{% for ip in (groups['cloud'] | map('extract', hostvars, ['eucalyptus_host_public_ipv4'])) %}
+newServer({address="{{ ip }}:{{ cloud_dns_listener_port|default(53) }}", checkName="ec2." .. EUCALYPTUS_DNSDOMAIN})
+{% endfor %}
+addLocal("{{ dnsdist_listener_address|default(eucalyptus_host_public_ipv4) }}:{{ dnsdist_listener_port|default(5353) }}", {reusePort=true})
+setACL({"0.0.0.0/0", "::/0"})
+
+--
+-- Static DNS responses
+--
+{% if dnsdist_console_ip|default() %}
+addAction("console." .. EUCALYPTUS_DNSDOMAIN, SpoofAction("{{ dnsdist_console_ip | quote }}"))
+{% elif dnsdist_console_cname|default() %}
+addAction("console." .. EUCALYPTUS_DNSDOMAIN, SpoofCNAMEAction("{{ dnsdist_console_cname | quote }}"))
+{% else %}
+-- addAction("console.{{ cloud_system_dns_dnsdomain }}", SpoofAction("10.20.30.40"))
+-- addAction("cname-console.{{ cloud_system_dns_dnsdomain }}", SpoofCNAMEAction("console.{{ cloud_system_dns_dnsdomain }}"))
+{% endif %}
+
+{% if dnsdist_cache_enabled|default(True) %}
+--
+-- Cache configuration
+--
+cache = newPacketCache(10000, 86400, 0, 60, 60)
+getPool(""):setCache(cache)
+setStaleCacheEntriesTTL({{ dnsdist_cache_entry_ttl | default(3600) }})
+setCacheCleaningDelay({{ dnsdist_cache_clean_delay | default(60) }})
+
+{% if dnsdist_cache_clean_maintenance_enabled|default(True) %}
+--
+-- Maintenance hook to stop cache cleaning when backends are not
+-- available. Cached results will be returned up to StaleCacheEntriesTTL.
+--
+function maintenance()
+  servers = getPoolServers("")
+  anyUp = false
+  for _, server in ipairs(servers) do
+    if server.upStatus then
+      anyUp = true
+    end
+  end
+  if anyUp then
+      setCacheCleaningPercentage(100)
+  else
+      setCacheCleaningPercentage(0)
+  end
+end
+{% endif %}
+{% endif %}

--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -61,6 +61,15 @@
     - packages
   when: net_mode == "VPCMIDO"
 
+- name: install dnsdist package
+  yum:
+    name: dnsdist
+    state: present
+  tags:
+    - image
+    - packages
+  when: cloud_dns_authoritative_balancer
+
 - name: eucalyptus firewalld service
   copy:
     src: firewalld-service-eucalyptus.xml

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -67,5 +67,8 @@ net_node_listen_addr: "{{ eucalyptus_host_cluster_ipv4 }}"
 net_node_router_enabled: "{{ edge_router_enabled }}"
 net_node_router_ip: "{{ edge_router_ip }}"
 
+# DNS Settings
+cloud_dns_authoritative_balancer: no
+
 # Role settings
 key_facts: no

--- a/roles/none/tasks/main.yml
+++ b/roles/none/tasks/main.yml
@@ -64,6 +64,14 @@
   register: systemd_result
   failed_when: "systemd_result is failed and 'Could not find the requested service' not in systemd_result.msg"
 
+- name: disable dnsdist@eucalyptus service
+  systemd:
+    enabled: false
+    state: stopped
+    name: dnsdist@eucalyptus
+  register: systemd_result
+  failed_when: "systemd_result is failed and 'Could not find the requested service' not in systemd_result.msg"
+
 - name: stop ceph target
   systemd:
     enabled: false
@@ -203,6 +211,11 @@
 - name: remove zookeeper state directory
   file:
     path: /var/lib/zookeeper
+    state: absent
+
+- name: remove dnsdist configuration
+  file:
+    path: /etc/dnsdist/dnsdist-eucalyptus.conf
     state: absent
 
 - name: remove ceph configuration directory


### PR DESCRIPTION
Add support for configuration of `dnsdist` on the public dns port along with optional dns naming for the console. An example of options you could put in an inventory:

```
    cloud_dns_listener_port: 8753
    cloud_dns_authoritative_balancer: yes
    dnsdist_listener_port: 53
    dnsdist_console_cname: "ec2.{{ cloud_system_dns_dnsdomain }}"
```

This example would move the cloud internal dns to port `8753` and configure `dnsdist` on port `53` including a CNAME for the console.

The default `dnsdist` configuration includes caching of responses for fallback use when the internal dns is not available (e.g. there is one `eucalyptus-cloud` service and it is stopped)