### PR TITLE
Management console deployment as stack and eucalyptus-cloud certbot support

### DIFF
--- a/host_groups.yml
+++ b/host_groups.yml
@@ -25,6 +25,15 @@
   when: "'host_zone_key' not in hostvars[inventory_hostname] and inventory_hostname == item.1"
   with_indexed_items: "{{ groups.node|sort }}"
 
+# console
+- name: console group default
+  add_host:
+    groups: console
+    hostname: "{{ item }}"
+    inventory_dir: "{{ hostvars[item].inventory_dir }}"
+  when: "'console' not in groups and not eucalyptus_console_cloud_deploy|default(False)"
+  with_items: "{{ groups.cloud }}"
+
 # ceph
 - name: node to ceph group for converged deployments
   add_host:

--- a/playbook.yml
+++ b/playbook.yml
@@ -33,7 +33,6 @@
       disablerepo: "{{ eucalyptus_yum_disablerepo | default(omit) }}"
   roles:
   - cloud
-  - console
 
 - hosts: zone
   module_defaults:
@@ -48,6 +47,13 @@
       disablerepo: "{{ eucalyptus_yum_disablerepo | default(omit) }}"
   roles:
   - node
+
+- hosts: console
+  module_defaults:
+    yum:
+      disablerepo: "{{ eucalyptus_yum_disablerepo | default(omit) }}"
+  roles:
+  - console
 
 - hosts: cloud
   roles:

--- a/roles/cloud-post/defaults/main.yml
+++ b/roles/cloud-post/defaults/main.yml
@@ -1,3 +1,18 @@
 ---
 # Network settings
 net_mode: EDGE
+
+# Eucalyptus management console stack deployment
+eucalyptus_console_cloud_deploy: no
+eucalyptus_console_account: console
+eucalyptus_console_ssh_cidr: "127.0.0.1/32"
+eucalyptus_console_web_cidr: "0.0.0.0/0"
+eucalyptus_console_instance_type: t2.small
+eucalyptus_console_certbot_enable: no
+eucalyptus_console_product: "{{ eucalyptus_product|default('eucalyptus') }}"
+
+# Certbot for eucalyptus-cloud
+eucalyptus_services_certbot_enable: no
+eucalyptus_services_certbot_email: ""
+eucalyptus_services_certbot_certonly_opts: "--no-eff-email"
+eucalyptus_services_endpoints: ['*', '*.s3']

--- a/roles/cloud-post/files/certbot-renew-eucalyptus-cloud.conf
+++ b/roles/cloud-post/files/certbot-renew-eucalyptus-cloud.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="AWS_DATA_PATH=/etc/eucalyptus/botocore/"

--- a/roles/cloud-post/files/console-manage-stack
+++ b/roles/cloud-post/files/console-manage-stack
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# Manage the console stack:
+#
+#    console-manage-stack [-h] [-a {create,delete,check}]
+#
+# Create, delete or check the status for the management console stack.
+#
+set -euo pipefail
+
+# Process arguments
+CMS_ACTION="check"
+while (( "$#" )); do
+  CMS_ARG="$1"
+  case "${CMS_ARG}" in
+    -a|--action)
+      shift
+      CMS_ACTION="$1"
+      ;;
+    -d|--debug)
+      set -x
+      ;;
+    *)
+      echo -e "Usage:\n\n\tconsole-manage-stack [-h] [-a {create,delete,check}]\n"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# Required configuration
+CONSOLE_IMAGEID=""
+
+# Source configuration
+if [ -f "/etc/eucalyptus/console.conf" ] ; then
+  . "/etc/eucalyptus/console.conf"
+fi
+
+if [ -z "${CONSOLE_IMAGEID}" ] ; then
+  echo "Console image configuration not found" >&2
+  exit 1
+fi
+
+# Detect configuration or use default
+CONSOLE_ACCOUNT="${CONSOLE_ACCOUNT:-console}"
+CONSOLE_BRANDING="${CONSOLE_BRANDING:-eucalyptus}"
+CONSOLE_CERTBOT="${CONSOLE_CERTBOT:-no}"
+CONSOLE_EIPALLOCID="${CONSOLE_EIPALLOCID:-}"
+CONSOLE_IMAGEID="${CONSOLE_IMAGEID:-}"
+CONSOLE_INSTANCETYPE="${CONSOLE_INSTANCETYPE:-t2.small}"
+CONSOLE_SSHCIDR="${CONSOLE_SSHCIDR:-127.0.0.1/32}"
+CONSOLE_SUBNETID="${CONSOLE_SUBNETID:-}"
+CONSOLE_UFSPORT="${CONSOLE_UFSPORT:-8773}"
+CONSOLE_VPCID="${CONSOLE_VPCID:-}"
+CONSOLE_WEBCIDR="${CONSOLE_WEBCIDR:-0.0.0.0/0}"
+
+# Verify running as console or can impersonate console account
+if [ "$(euare-accountlist | cut -f 1)" != "${CONSOLE_ACCOUNT}" ] ; then
+  eval $(clcadmin-impersonate-user -a "${CONSOLE_ACCOUNT}")
+fi
+
+if [ -z "${CONSOLE_VPCID}" ] ; then
+  CONSOLE_VPCID="$(euca-describe-account-attributes "default-vpc" | grep "VALUE" | cut -f 2)"
+  [ -n "${CONSOLE_VPCID}" ] || echo "Could not detect vpc configuration" >&2
+fi
+
+if [ -z "${CONSOLE_SUBNETID}" ] && [ -n "${CONSOLE_VPCID}" ]; then
+  CONSOLE_SUBNETID="$(euca-describe-subnets --filter "vpc-id=${CONSOLE_VPCID}" --filter "default-for-az=true" | head -n 1 | cut -f 2)"
+  [ -n "${CONSOLE_SUBNETID}" ] || echo "Could not detect subnet configuration" >&2
+fi
+
+if [ -z "${CONSOLE_EIPALLOCID}" ] ; then
+  CONSOLE_EIPALLOCID="$(euca-describe-tags --filter resource-type=elastic-ip --filter key=aws:cloudformation:stack-name --filter value=console-eip | cut -f 3)"
+  [ -n "${CONSOLE_EIPALLOCID}" ] || echo "Could not detect eip configuration, check console-eip stack exists." >&2
+fi
+
+if [ "${CMS_ACTION}" = "check" ] ; then
+  if ! euform-describe-stacks "console" | grep "^STACK" ; then
+    echo "STACK\tconsole\tNOT_FOUND"
+  fi
+elif  [ "${CMS_ACTION}" = "create" ] ; then
+  if [ -z "${CONSOLE_EIPALLOCID}" ] || [ -z "${CONSOLE_SUBNETID}" ] || [ -z "${CONSOLE_VPCID}" ] ; then
+    exit 1
+  fi
+
+  euform-create-stack \
+    --template-file "/var/lib/eucalyptus/templates/console-template.yaml" \
+    --capabilities "CAPABILITY_IAM" \
+    -p ElasticIpAllocationId="${CONSOLE_EIPALLOCID}" \
+    -p EnableCertbot="${CONSOLE_CERTBOT}" \
+    -p Branding="${CONSOLE_BRANDING}" \
+    -p UfsPort="${CONSOLE_UFSPORT}" \
+    -p InstanceType="${CONSOLE_INSTANCETYPE}" \
+    -p ImageId="${CONSOLE_IMAGEID}" \
+    -p SubnetId="${CONSOLE_SUBNETID}" \
+    -p VpcId="${CONSOLE_VPCID}" \
+    -p SshCidr="${CONSOLE_SSHCIDR}" \
+    -p ConsoleCidr="${CONSOLE_WEBCIDR}" \
+    "console"
+elif  [ "${CMS_ACTION}" = "delete" ] ; then
+  euform-delete-stack "console"
+else
+  echo "Invalid action: ${CMS_ACTION}" >&2
+  exit 3
+fi
+

--- a/roles/cloud-post/tasks/certbot.yml
+++ b/roles/cloud-post/tasks/certbot.yml
@@ -1,0 +1,132 @@
+---
+# Provision and renew letsencrypt https certificate for services using certbot
+
+- name: install certbot packages
+  yum:
+    name:
+    - certbot
+    - python2-certbot-dns-route53
+    - python2-futures
+    state: present
+  tags:
+    - packages
+
+- name: certbot-renew service.d directory
+  file:
+    path: /etc/systemd/system/certbot-renew.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: certbot-renew eucalyptus-cloud environment
+  copy:
+    src: certbot-renew-eucalyptus-cloud.conf
+    dest: /etc/systemd/system/certbot-renew.service.d/eucalyptus-cloud.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: certbot route53 system domain for eucalyptus-cloud authentication
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euform-create-stack \
+      --template-file /var/lib/eucalyptus/templates/eucalyptus-dns-template.yaml \
+      eucalyptus-dns
+  register: shell_result
+  changed_when: '"AlreadyExists" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - '"AlreadyExists" not in shell_result.stderr'
+
+- name: certbot firstboot certificate for eucalyptus-cloud
+  shell: |
+    cat <<"EOF" |
+    import com.eucalyptus.component.auth.SystemCredentials
+    import com.eucalyptus.configurable.PropertyDirectory
+    import com.eucalyptus.crypto.Certs
+    import com.eucalyptus.crypto.util.PEMFiles
+    import edu.ucsb.eucalyptus.cloud.entities.SystemConfiguration
+    String alias = 'firstboot'
+    String domain = SystemConfiguration.systemConfiguration.dnsDomain
+    String wildhost = "*.${domain}"
+    LinkedHashSet<String> altNames = [wildhost, "*.s3.${domain}" as String]
+    def keyPair = Certs.generateKeyPair( )
+    def certificate = Certs.generateServiceCertificate( keyPair, wildhost, altNames )
+    SystemCredentials.keyStore.addKeyPair( alias, certificate, keyPair.getPrivate( ), '' )
+    PropertyDirectory.getPropertyEntry( 'bootstrap.webservices.ssl.server_alias' ).setValue( alias )
+    """\
+    ${alias}
+    ${new String( PEMFiles.getBytes( certificate ), java.nio.charset.StandardCharsets.UTF_8 )}
+    """
+    EOF
+    euctl euca=@/dev/stdin > /var/lib/eucalyptus/keys/firstboot.pem
+  args:
+    creates: /var/lib/eucalyptus/keys/firstboot.pem
+
+- name: wait for certbot firstboot certificate for eucalyptus-cloud
+  shell: |
+    set -eu
+    HEARTBEAT_URL="https://bootstrap.{{ cloud_system_dns_dnsdomain | quote }}:{{ cloud_public_port | default(8773) }}/services/Heartbeat"
+    wget \
+      --ca-certificate /var/lib/eucalyptus/keys/firstboot.pem \
+      --quiet \
+      --output-document - \
+      "${HEARTBEAT_URL}"
+  register: shell_result
+  changed_when: False
+  until: shell_result is succeeded
+  retries: 5
+
+- name: certbot-renew aws data path directory for eucalyptus-cloud
+  file:
+    path: /etc/eucalyptus/botocore
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: certbot-renew aws configuration for eucalyptus-cloud
+  template:
+    src: botocore-endpoints.json.j2
+    dest: /etc/eucalyptus/botocore/endpoints.json
+    owner: root
+    group: root
+    mode: 0644
+
+- name: eucalyptus services certbot https
+  shell: |
+    set -eu
+    SERVICE_DOMAINS="{{ eucalyptus_services_endpoints | map('regex_replace', '^(.*)$', '\1.' + cloud_system_dns_dnsdomain) | list | unique | sort | join(',') }}"
+    REGISTRATION_EMAIL={{ eucalyptus_services_certbot_email | quote }}
+    EXTRA_OPTS={{ eucalyptus_services_certbot_certonly_opts | quote }}
+    if [ -z "${REGISTRATION_EMAIL}" ] ; then
+      EXTRA_OPTS="${EXTRA_OPTS} --register-unsafely-without-email"
+    else
+      EXTRA_OPTS="${EXTRA_OPTS} --email ${REGISTRATION_EMAIL}"
+    fi
+    export AWS_DATA_PATH=/etc/eucalyptus/botocore/
+    export AWS_CA_BUNDLE=/var/lib/eucalyptus/keys/firstboot.pem
+    certbot certonly \
+      --non-interactive \
+      --agree-tos \
+      --cert-name eucalyptus-cloud \
+      --domain "${SERVICE_DOMAINS}" \
+      --dns-route53 \
+      --deploy-hook /usr/local/bin/eucalyptus-cloud-https-import \
+      ${EXTRA_OPTS}
+  args:
+    creates: /etc/letsencrypt/live/eucalyptus-cloud/fullchain.pem
+
+- name: eucalyptus services certbot https renewal
+  systemd:
+    enabled: true
+    state: started
+    name: certbot-renew.timer
+
+- name: configure cloud property for services https
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euctl bootstrap.webservices.ssl.server_alias=eucalyptus-cloud

--- a/roles/cloud-post/tasks/console.yml
+++ b/roles/cloud-post/tasks/console.yml
@@ -1,0 +1,125 @@
+---
+- name: install console image
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    /usr/local/bin/eucalyptus-system-images --type console --size 10
+  register: shell_result
+  changed_when: '"image already installed" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - shell_result.rc != 2
+
+- name: console account
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euare-accountcreate -a "{{ eucalyptus_console_account | quote }}"
+  register: shell_result
+  changed_when: '"EntityAlreadyExists" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - '"EntityAlreadyExists" not in shell_result.stderr'
+
+- name: console account image launch permission
+  shell: |
+    set -euo pipefail
+    eval $(clcadmin-assume-system-credentials)
+    CONSOLE_IMAGEID=$(euca-describe-images --filter tag:type=eucalyptus-console-image | head -n 1 | grep ^IMAGE | cut -f 2)
+    CONSOLE_ACCOUNT=$(euare-accountlist | grep "^{{ eucalyptus_console_account | quote }}[[:space:]]" | cut -f 2)
+    euca-modify-image-attribute -l -a "${CONSOLE_ACCOUNT}" "${CONSOLE_IMAGEID}"
+
+- name: console route53 system domain for eucalyptus-cloud authentication
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euform-create-stack \
+      --template-file /var/lib/eucalyptus/templates/eucalyptus-dns-template.yaml \
+      eucalyptus-dns
+  register: shell_result
+  changed_when: '"AlreadyExists" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - '"AlreadyExists" not in shell_result.stderr'
+
+- name: console elastic ip address stack
+  shell: |
+    set -eu
+    eval $(clcadmin-impersonate-user -a "{{ eucalyptus_console_account | quote }}")
+    euform-create-stack --template-file /var/lib/eucalyptus/templates/console-eip-template.yaml console-eip
+  register: shell_result
+  changed_when: '"AlreadyExists" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - '"AlreadyExists" not in shell_result.stderr'
+
+- name: wait for console elastic ip address stack
+  shell: |
+    set -euo pipefail
+    eval $(clcadmin-impersonate-user -a "{{ eucalyptus_console_account | quote }}")
+    euform-describe-stacks console-eip | grep CREATE_COMPLETE
+  register: shell_result
+  changed_when: False
+  until: shell_result is succeeded
+  retries: 5
+
+- name: console elastic ip address
+  shell: |
+    set -euo pipefail
+    eval $(clcadmin-impersonate-user -a "{{ eucalyptus_console_account | quote }}")
+    euform-describe-stack-resource -l ElasticIp console-eip | cut -f 3
+  register: shell_result
+  changed_when: False
+
+- name: update console route53 system domain for eucalyptus-cloud authentication
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euform-update-stack \
+      --template-file /var/lib/eucalyptus/templates/eucalyptus-dns-template.yaml \
+      -p ConsoleIpAddress={{ shell_result.stdout }} \
+      eucalyptus-dns
+  register: shell_result
+  changed_when: '"AlreadyExists" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - '"AlreadyExists" not in shell_result.stderr'
+
+- name: console image identifier lookup
+  shell: |
+    set -euo pipefail
+    eval $(clcadmin-assume-system-credentials)
+    euca-describe-images --filter tag:type=eucalyptus-console-image | head -n 1 | grep ^IMAGE | cut -f 2
+  register: shell_result
+  changed_when: False
+
+- name: console image identifier fact
+  set_fact:
+    eucalyptus_console_image_id: "{{ shell_result.stdout }}"
+
+- name: console manage stack command
+  copy:
+    src: console-manage-stack
+    dest: /usr/local/bin/console-manage-stack
+    owner: root
+    group: root
+    mode: 0755
+
+- name: console stack configuration
+  template:
+    src: console.conf.j2
+    dest: /etc/eucalyptus/console.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: console stack
+  shell: |
+    set -euo pipefail
+    eval $(clcadmin-assume-system-credentials)
+    /usr/local/bin/console-manage-stack -a create
+  register: shell_result
+  changed_when: '"AlreadyExists" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - '"AlreadyExists" not in shell_result.stderr'

--- a/roles/cloud-post/tasks/main.yml
+++ b/roles/cloud-post/tasks/main.yml
@@ -2,6 +2,12 @@
 - import_tasks: vpcmido.yml
   when: net_mode == "VPCMIDO"
 
+- import_tasks: console.yml
+  when: eucalyptus_console_cloud_deploy and net_mode == "VPCMIDO"
+
+- import_tasks: certbot.yml
+  when: eucalyptus_services_certbot_enable
+
 - name: enable imaging service
   shell: |
     set -eu

--- a/roles/cloud-post/templates/botocore-endpoints.json.j2
+++ b/roles/cloud-post/templates/botocore-endpoints.json.j2
@@ -1,0 +1,79 @@
+{
+  "partitions" : [ {
+    "defaults" : {
+      "hostname" : "{service}.{dnsSuffix}",
+      "protocols" : [ "https" ],
+      "signatureVersions" : [ "v4" ]
+    },
+    "dnsSuffix" : "{{ cloud_system_dns_dnsdomain | quote }}:{{ cloud_public_port | default(8773) }}",
+    "partition" : "aws",
+    "partitionName" : "AWS Standard",
+    "regionRegex" : "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    "regions" : {
+      "eucalyptus" : {
+        "description" : "Eucalyptus Cloud"
+      }
+    },
+    "services" : {
+      "autoscaling" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "cloudformation" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "ec2" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "elasticloadbalancing" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "iam" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "monitoring" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "route53" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "s3" : {
+        "defaults" : {
+          "signatureVersions" : [ "s3v4" ]
+        },
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "sqs" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "sts" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      },
+      "swf" : {
+        "endpoints" : {
+          "eucalyptus" : { }
+        }
+      }
+    }
+  } ],
+  "version" : 3
+}

--- a/roles/cloud-post/templates/console.conf.j2
+++ b/roles/cloud-post/templates/console.conf.j2
@@ -1,0 +1,12 @@
+# Configuration for console stack deployments
+#
+# See console-manage-stack
+#
+
+CONSOLE_BRANDING="{{ eucalyptus_console_product | quote }}"
+CONSOLE_CERTBOT="{{ 'yes' if eucalyptus_console_certbot_enable else 'no' }}"
+CONSOLE_IMAGEID="{{ eucalyptus_console_image_id | quote }}"
+CONSOLE_INSTANCETYPE="{{ eucalyptus_console_instance_type | quote }}"
+CONSOLE_UFSPORT="{{ cloud_public_port | default(8773) }}"
+CONSOLE_SSHCIDR="{{ eucalyptus_console_ssh_cidr | quote }}"
+CONSOLE_WEBCIDR="{{ eucalyptus_console_web_cidr | quote }}"

--- a/roles/cloud/defaults/main.yml
+++ b/roles/cloud/defaults/main.yml
@@ -2,7 +2,10 @@
 # Cloud settings
 cloud_region_region_name: "{{ cloud_region_name }}"
 cloud_listener_cidr: 0.0.0.0/0
+cloud_listener_port: "{{ cloud_public_port }}"
+cloud_public_port: 8773
 cloud_properties: {}
+cloud_admin_password: ""
 
 # EDGE network settings
 edge_subnet: "{{ '172.31.0.0' if edge_bridge_create else ansible_default_ipv4.network }}"

--- a/roles/cloud/files/console-eip-template.yaml
+++ b/roles/cloud/files/console-eip-template.yaml
@@ -1,0 +1,25 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  EC2 VPC elastic IP address for Eucalyptus Console
+
+Resources:
+
+  ElasticIp:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+      - Key: Name
+        Value: Management Console
+
+Outputs:
+
+  ElasticIp:
+    Description: The IP address for the console
+    Value: !Ref ElasticIp
+
+  ElasticIpAllocationId:
+    Description: The IP address allocation identifier for the console
+    Value: !GetAtt ElasticIp.AllocationId
+

--- a/roles/cloud/files/console-template.yaml
+++ b/roles/cloud/files/console-template.yaml
@@ -1,0 +1,261 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Eucalyptus Console VPC template for use with console image
+
+Parameters:
+
+  ElasticIpAllocationId:
+    Description: The allocation identifier for the console public IP
+    Type: String
+
+  EnableCertbot:
+    Description: Provision HTTPS certificate using certbot
+    Type: String
+    AllowedValues:
+    - "yes"
+    - "no"
+    Default: "no"
+
+  Branding:
+    Description: Console branding
+    Type: String
+    AllowedValues:
+    - ats
+    - eucalyptus
+    Default: eucalyptus
+
+  UfsPort:
+    Description: Port to use for cloud services
+    Type: String
+    Default: 8773
+
+  InstanceType:
+    Description: Instance type to use
+    Type: String
+    Default: t2.small
+
+  ImageId:
+    Description: Identifier for the eucaconsole image
+    Type: String
+
+  KeyName:
+    Description: EC2 keypair for instance SSH access
+    Type: String
+    Default: ''
+
+  SubnetId:
+    Description: The subnet to use
+    Type: String
+
+  VpcId:
+    Description: The vpc to use
+    Type: String
+
+  SshCidr:
+    Description: CIDR for permitted SSH source IP addresses
+    Type: String
+    Default: "127.0.0.1/32"
+
+  ConsoleCidr:
+    Description: CIDR for permitted http(s) source IP addresses
+    Type: String
+    Default: "0.0.0.0/0"
+
+Conditions:
+
+  UseKeyNameParameter: !Not
+    - !Equals
+      - !Ref KeyName
+      - ''
+
+Mappings:
+
+  Brandings:
+    eucalyptus:
+      ImageFavicon: favicon.ico
+      ImageLogo: console-logo.png
+      LocaleSuffix: ""
+      ProductUrl: https://github.com/Corymbia/eucalyptus/
+    ats:
+      ImageFavicon: ats-favicon.ico
+      ImageLogo: ats-console-logo.png
+      LocaleSuffix: "@ATS"
+      ProductUrl: https://www.appscale.com/product/
+
+Resources:
+
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Console security group
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '22'
+          ToPort: '22'
+          CidrIp: !Ref SshCidr
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: !Ref ConsoleCidr
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: !Ref ConsoleCidr
+
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: Allow
+          Action: sts:AssumeRole
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+      Policies:
+      - PolicyName: eucaconsole-ec2-addresses
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action: "ec2:*Address*"
+            Resource: "*"
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /
+      Roles:
+      - !Ref Role
+
+  LaunchConfiguration:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      ImageId: !Ref ImageId
+      InstanceType: !Ref InstanceType
+      InstanceMonitoring: false
+      IamInstanceProfile: !Ref InstanceProfile
+      AssociatePublicIpAddress: true
+      SecurityGroups:
+      - !Ref SecurityGroup
+      KeyName: !If
+      - UseKeyNameParameter
+      - !Ref 'KeyName'
+      - !Ref 'AWS::NoValue'
+      UserData: !Base64
+        "Fn::Sub":
+        - |
+          #cloud-config
+          write_files:
+          - path: /etc/eucaconsole/nginx.conf.d/40-nginx-ats-static.conf
+            permissions: "0644"
+            owner: root
+            content: |
+              # nginx configuration fragment for ATS console assets
+              
+              location =/static/img/favicon.ico {
+                  alias                   /usr/lib/python2.7/site-packages/eucaconsole/static/img/${ImageFavicon};
+                  include                 /etc/nginx/mime.types;
+                  add_header              Cache-Control public;
+                  expires                 30d;
+                  access_log              off;
+              }
+              
+              location =/static/img/console-logo.png {
+                  alias                   /usr/lib/python2.7/site-packages/eucaconsole/static/img/${ImageLogo};
+                  include                 /etc/nginx/mime.types;
+                  add_header              Cache-Control public;
+                  expires                 30d;
+                  access_log              off;
+              }
+          - path: /etc/eucaconsole/console-cloud-config.ini
+            permissions: "0644"
+            owner: root
+            content: |
+              ##############################################
+              # Eucalyptus Management Console Cloud Config #
+              ##############################################
+              
+              [app:main]
+              use = egg:eucaconsole
+              
+              # Eucalyptus settings
+              ufshost = ${AWS::URLSuffix}
+              ufsport = ${UfsPort}
+              
+              # Branding settings
+              product.url = ${ProductUrl}
+              pyramid.default_locale_name = en${LocaleSuffix}
+              pyramid.locale_negotiator = eucaconsole.i18n.fixed_locale_negotiator
+              
+              # AWS settings
+              aws.enabled = false
+              aws.default.region = us-east-1
+          - path: /etc/eucaconsole/eucaconsole-domain.txt
+            permissions: "0644"
+            owner: root
+            content: "console.${AWS::URLSuffix}"
+          - path: /etc/eucaconsole/ec2-endpoint.txt
+            permissions: "0644"
+            owner: root
+            content: "http://ec2.${AWS::URLSuffix}:${UfsPort}/"
+          - path: /etc/eucaconsole/elastic-ip-allocation.txt
+            permissions: "0644"
+            owner: root
+            content: ${ElasticIpAllocationId}
+          - path: /etc/systemd/system/eucaconsole-certbot-init.service
+            permissions: "0644"
+            owner: root
+            content: |
+              [Unit]
+              Description=Eucalyptus Console Certbot Initialization
+              After=eucaconsole.service
+              Requires=eucaconsole.service
+              AssertPathExists=/etc/eucaconsole/eucaconsole-domain.txt
+              
+              [Service]
+              Type=simple
+              ExecStart=/bin/sh -c "[ -d /etc/letsencrypt/live/eucaconsole ] || { sleep 30; /usr/bin/eucaconsole-certbot-init $(</etc/eucaconsole/eucaconsole-domain.txt); }"
+              RemainAfterExit=true
+              Restart=on-failure
+              RestartSec=60
+              StartLimitInterval=24h
+              StartLimitBurst=2
+              TimeoutStartSec=300
+          runcmd:
+          - "[ ${EnableCertbot} != yes ] || systemctl enable --now eucaconsole-certbot-init.service"
+        - ImageFavicon: !FindInMap
+          - Brandings
+          - !Ref Branding
+          - ImageFavicon
+          ImageLogo: !FindInMap
+          - Brandings
+          - !Ref Branding
+          - ImageLogo
+          LocaleSuffix: !FindInMap
+          - Brandings
+          - !Ref Branding
+          - LocaleSuffix
+          ProductUrl: !FindInMap
+          - Brandings
+          - !Ref Branding
+          - ProductUrl
+
+  AutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+        VPCZoneIdentifier:
+        - !Ref SubnetId
+        LaunchConfigurationName: !Ref LaunchConfiguration
+        MinSize: 0
+        MaxSize: 1
+        DesiredCapacity: 1
+        Tags:
+        - Key: Name
+          Value: eucalyptus-console
+          PropagateAtLaunch: true
+

--- a/roles/cloud/files/eucalyptus-cloud-https-import
+++ b/roles/cloud/files/eucalyptus-cloud-https-import
@@ -2,9 +2,14 @@
 # Import HTTPS key/certificate from PEM files
 set -eo pipefail
 
-KEY_ALIAS="eucaconsole"
+KEY_ALIAS="eucalyptus-cloud"
 PEM_KEY="/etc/pki/tls/private/eucaconsole.key"
 PEM_CERTS="/etc/pki/tls/certs/eucaconsole.crt"
+
+if [ -d "${RENEWED_LINEAGE:-/does/not/exist}" ] ; then
+  PEM_KEY="${RENEWED_LINEAGE}/privkey.pem"
+  PEM_CERTS="${RENEWED_LINEAGE}/fullchain.pem"
+fi
 
 while (( "$#" )); do
   IMPORT_ARG="$1"

--- a/roles/cloud/files/eucalyptus-dns-template.yaml
+++ b/roles/cloud/files/eucalyptus-dns-template.yaml
@@ -1,0 +1,111 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Route53 system HostedZone and management console dns for Eucalyptus
+
+Parameters:
+
+  SystemDnsDomain:
+    Description: The system dns domain in use
+    Type: String
+    Default: ""
+
+  ConsoleCname:
+    Description: Name for a Eucalyptus Console CNAME record
+    Type: String
+    Default: ""
+
+  ConsoleIpAddress:
+    Description: IP address for a Eucalyptus Console A record
+    Type: String
+    Default: ""
+
+Conditions:
+
+  CreateConsoleARecordSet: !Not
+  - !Equals
+    - !Ref ConsoleIpAddress
+    - ""
+
+  CreateConsoleCnameRecordSet: !Not
+  - !Equals
+    - !Ref ConsoleCname
+    - ""
+
+  UseSystemDnsDomainParameter: !Not
+  - !Equals
+    - !Ref SystemDnsDomain
+    - ""
+
+Resources:
+
+  HostedZone:
+    Type: AWS::Route53::HostedZone
+    Properties:
+      HostedZoneConfig:
+        Comment:
+      Name: !If
+        - UseSystemDnsDomainParameter
+        - !Ref "SystemDnsDomain"
+        - !Ref "AWS::URLSuffix"
+
+  SOARecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZone
+      Name: !If
+        - UseSystemDnsDomainParameter
+        - !Ref "SystemDnsDomain"
+        - !Ref "AWS::URLSuffix"
+      ResourceRecords:
+      - !Sub
+        - "ns1.${SystemDomain}. root.${SystemDomain}. 1 3600 600 86400 3600"
+        - SystemDomain: !If
+          - UseSystemDnsDomainParameter
+          - !Ref "SystemDnsDomain"
+          - !Ref "AWS::URLSuffix"
+      TTL: 60
+      Type: SOA
+
+  ConsoleARecordSet:
+    Type: AWS::Route53::RecordSet
+    Condition: CreateConsoleARecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZone
+      Name: !Sub
+        - "console.${SystemDomain}"
+        - SystemDomain: !If
+          - UseSystemDnsDomainParameter
+          - !Ref "SystemDnsDomain"
+          - !Ref "AWS::URLSuffix"
+      ResourceRecords:
+      - !Ref ConsoleIpAddress
+      TTL: 900
+      Type: A
+
+  ConsoleCnameRecordSet:
+    Type: AWS::Route53::RecordSet
+    Condition: CreateConsoleCnameRecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZone
+      Name: !Sub
+        - "console.${SystemDomain}"
+        - SystemDomain: !If
+          - UseSystemDnsDomainParameter
+          - !Ref "SystemDnsDomain"
+          - !Ref "AWS::URLSuffix"
+      ResourceRecords:
+      - !Sub
+        - "compute.${SystemDomain}"
+        - SystemDomain: !If
+          - UseSystemDnsDomainParameter
+          - !Ref "SystemDnsDomain"
+          - !Ref "AWS::URLSuffix"
+      TTL: 1800
+      Type: CNAME
+
+Outputs:
+
+  HostedZoneId:
+    Description: The identifier for the system hosted zone
+    Value: !Ref HostedZone

--- a/roles/cloud/files/eucalyptus-system-images
+++ b/roles/cloud/files/eucalyptus-system-images
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Eucalyptus system image management script
+set -euo pipefail
+
+IMAGE_SIZE="5"
+IMAGE_TYPE="console" # or service
+IMAGE_REPORT="no"
+
+while (( "$#" )); do
+  IMAGES_ARG="$1"
+  case "${IMAGES_ARG}" in
+    --report)
+      IMAGE_REPORT="yes"
+      ;;
+    --size)
+      shift
+      IMAGE_SIZE="$1"
+      ;;
+    --type)
+      shift
+      IMAGE_TYPE="$1"
+      ;;
+    *)
+      echo -e "Usage:\n\n\teucalyptus-system-images [--report] [--size SIZE] [--type (console|service)]\n"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+IMAGE_TMPDIR="/var/lib/eucalyptus/upgrade"
+IMAGE_TEMPLATE="image.XXXXXXXX"
+IMAGE_URL_PREFIX="https://downloads.eucalyptus.cloud/software/eucalyptus/images"
+IMAGE_FULL_TYPE="eucalyptus-${IMAGE_TYPE}-image"
+IMAGE_LATEST_URL="${IMAGE_URL_PREFIX}/latest-${IMAGE_FULL_TYPE}.txt"
+
+if [ "yes" = "${IMAGE_REPORT}" ] ; then
+  for IMAGE_TYPE in "console" "service" ; do
+    IMAGE_FULL_TYPE="eucalyptus-${IMAGE_TYPE}-image"
+    IMAGE_LATEST_URL="${IMAGE_URL_PREFIX}/latest-${IMAGE_FULL_TYPE}.txt"
+    IMAGE_URL=$(wget --quiet --output-document - ${IMAGE_LATEST_URL} | grep "${IMAGE_URL_PREFIX}")
+    IMAGE_NAME=$(basename "${IMAGE_URL}")
+    IMAGE_VERSION_DOT=$(echo "${IMAGE_NAME}" | sed 's/.raw.xz$//' | cut --delimiter "-" --output-delimiter "." --fields "4-10")
+    echo -e "TYPE\t${IMAGE_FULL_TYPE}\tVERSION\t${IMAGE_VERSION_DOT}"
+  done
+  exit 0
+fi
+
+IMAGE_WORK=$(mktemp --directory --tmpdir="${IMAGE_TMPDIR}" "${IMAGE_TEMPLATE}")
+function cleanup {
+  [ ! -d "${IMAGE_WORK}" ] || rm -rf "${IMAGE_WORK}"
+}
+trap cleanup EXIT
+IMAGE_URL=$(wget --quiet --output-document - ${IMAGE_LATEST_URL} | grep "${IMAGE_URL_PREFIX}")
+IMAGE_NAME=$(basename "${IMAGE_URL}")
+IMAGE_VERSION_DASH=$(echo "${IMAGE_NAME}" | sed 's/.raw.xz$//' | cut --delimiter "-" --fields "4-10")
+IMAGE_VERSION_DOT=$(echo "${IMAGE_NAME}" | sed 's/.raw.xz$//' | cut --delimiter "-" --output-delimiter "." --fields "4-10")
+
+# check
+IMAGE_ID=$(euca-describe-images --filter "tag:type=${IMAGE_FULL_TYPE}" --filter "tag:version=${IMAGE_VERSION_DOT}" | grep ^IMAGE | cut -f 2 || true)
+IMAGE_INSTALLED="no"
+if [ -n "${IMAGE_ID}" ] ; then
+  IMAGE_INSTALLED="yes"
+  echo "Latest image already installed ${IMAGE_FULL_TYPE} v${IMAGE_VERSION_DOT} as ${IMAGE_ID}" 1>&2
+  exit 2
+fi
+
+# download
+wget --quiet --output-document "${IMAGE_WORK}/${IMAGE_NAME}" "${IMAGE_URL}"
+unxz "${IMAGE_WORK}/${IMAGE_NAME}"
+truncate --size="${IMAGE_SIZE}GiB" --no-create "${IMAGE_WORK}/${IMAGE_NAME%%.xz}"
+
+# install
+IMAGE_ID=$(euca-install-image \
+  -r "x86_64" \
+  -i "${IMAGE_WORK}/${IMAGE_NAME%%.xz}" \
+  --virt "hvm" \
+  -b "${IMAGE_FULL_TYPE}-${IMAGE_VERSION_DASH}" \
+  -n "${IMAGE_FULL_TYPE}-${IMAGE_VERSION_DASH}" \
+| grep IMAGE | cut -f 2)
+
+IMAGE_EXTRA_TAGS=""
+if [ "service" = "${IMAGE_TYPE}" ] ; then
+  IMAGE_EXTRA_TAGS="${IMAGE_EXTRA_TAGS} --tag provides=imaging,loadbalancing"
+fi
+euca-create-tags \
+  ${IMAGE_EXTRA_TAGS} \
+  --tag "type=${IMAGE_FULL_TYPE}" \
+  --tag "version=${IMAGE_VERSION_DOT}" \
+  "${IMAGE_ID}" > "/dev/null"
+
+echo -e "IMAGE\t${IMAGE_ID}"

--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -71,8 +71,8 @@
   when: cloud_dns_authoritative_balancer
 
 - name: eucalyptus firewalld service
-  copy:
-    src: firewalld-service-eucalyptus.xml
+  template:
+    src: firewalld-service-eucalyptus.xml.j2
     dest: /etc/firewalld/services/eucalyptus.xml
     owner: root
     group: root
@@ -183,9 +183,11 @@
     eval $(clcadmin-assume-system-credentials)
     euctl system.dns.dnsdomain={{ cloud_system_dns_dnsdomain | quote }}
     euctl region.region_name={{ cloud_region_region_name | quote }}
+    euctl cloud.network.network_configuration=@/etc/eucalyptus/network.yaml
     euctl bootstrap.webservices.use_instance_dns=true
     euctl bootstrap.webservices.use_dns_delegation=true
-    euctl cloud.network.network_configuration=@/etc/eucalyptus/network.yaml
+    euctl bootstrap.webservices.port={{ cloud_listener_port | quote }}
+    euctl bootstrap.webservices.listener_address_match={{ cloud_listener_cidr | quote }}
   register: shell_result
   until: shell_result.rc == 0
   retries: 5
@@ -245,6 +247,38 @@
     group: root
     mode: 0755
 
+- name: cloudformation templates directory
+  file:
+    path: /var/lib/eucalyptus/templates
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: cloudformation template for eucalyptus dns
+  copy:
+    src: eucalyptus-dns-template.yaml
+    dest: /var/lib/eucalyptus/templates/eucalyptus-dns-template.yaml
+    owner: root
+    group: root
+    mode: 0644
+
+- name: cloudformation template for console elastic ip
+  copy:
+    src: console-eip-template.yaml
+    dest: /var/lib/eucalyptus/templates/console-eip-template.yaml
+    owner: root
+    group: root
+    mode: 0644
+
+- name: cloudformation template for console
+  copy:
+    src: console-template.yaml
+    dest: /var/lib/eucalyptus/templates/console-template.yaml
+    owner: root
+    group: root
+    mode: 0644
+
 - name: tools configuration directory
   file:
     path: /root/.euca
@@ -261,12 +295,24 @@
     group: root
     mode: 0644
 
+- name: admin password/login profile credential
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euare-useraddloginprofile -u admin -p "{{ cloud_admin_password | quote }}"
+  register: shell_result
+  when: cloud_admin_password|length >= 8
+  changed_when: '"EntityAlreadyExists" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - '"EntityAlreadyExists" not in shell_result.stderr'
+
 - name: generate admin credentials / configuration
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
     export AWS_DEFAULT_REGION=eucalyptus
-    euare-useraddkey --write-config --domain {{ cloud_system_dns_dnsdomain | quote }} --set-default-user admin > /root/.euca/euca-admin.ini
+    euare-useraddkey --write-config --domain "{{ cloud_system_dns_dnsdomain | quote }}:{{ cloud_public_port | default(8773) }}" --set-default-user admin > /root/.euca/euca-admin.ini
   args:
     creates: /root/.euca/euca-admin.ini
 
@@ -303,8 +349,10 @@
     group: root
     mode: 0755
 
-- name: configure cloud listener address match
-  shell: |
-    set -eu
-    eval $(clcadmin-assume-system-credentials)
-    euctl --region admin@localhost bootstrap.webservices.listener_address_match={{ cloud_listener_cidr | quote }}
+- name: eucalyptus-system-images system image install utility
+  copy:
+    src: eucalyptus-system-images
+    dest: /usr/local/bin/eucalyptus-system-images
+    owner: root
+    group: root
+    mode: 0755

--- a/roles/cloud/templates/aws-config.j2
+++ b/roles/cloud/templates/aws-config.j2
@@ -3,7 +3,7 @@ eucalyptus = awscli_plugin_eucalyptus
 
 [default]
 ufshost = {{ cloud_system_dns_dnsdomain }}
-ufsport = 8773
+ufsport = {{ cloud_public_port | default(8773) }}
 verify_ssl = no
 output = text
 region = eucalyptus

--- a/roles/cloud/templates/firewalld-service-eucalyptus.xml.j2
+++ b/roles/cloud/templates/firewalld-service-eucalyptus.xml.j2
@@ -2,5 +2,5 @@
 <service>
   <short>Eucalyptus Cloud</short>
   <description>Public endpoints for Eucalyptus Cloud web services (see also dns, http and https)</description>
-  <port protocol="tcp" port="8773"/>
+  <port protocol="tcp" port="{{ cloud_public_port | default(8773) }}"/>
 </service>

--- a/roles/console/defaults/main.yml
+++ b/roles/console/defaults/main.yml
@@ -3,12 +3,13 @@
 eucaconsole_product: "{{ eucalyptus_product }}"
 eucaconsole_ats_product_url: https://www.appscale.com/product/
 eucaconsole_firewalld_configure: yes
-eucaconsole_admin_password: ""
 
 # Certbot
 eucaconsole_certbot_configure: no
 eucaconsole_certbot_domain: "console.{{ cloud_system_dns_dnsdomain | default('localhost') }}"
 eucaconsole_certbot_email: ""
 eucaconsole_certbot_certonly_opts: "--no-eff-email"
-eucaconsole_certbot_request_service_domains: yes
-eucaconsole_certbot_services: [autoscaling, bootstrap, cloudformation, ec2, elasticloadbalancing, iam, monitoring, properties, s3, sqs, sts, swf]
+eucaconsole_certbot_request_service_domains: "{{ eucaconsole_certbot_services|length > 0 }}"
+eucaconsole_certbot_services: []
+eucaconsole_certbot_services_all: [autoscaling, bootstrap, cloudformation, ec2, elasticloadbalancing, iam, monitoring, properties, route53, s3, sqs, sts, swf]
+

--- a/roles/console/files/certbot-renew-eucaconsole.conf
+++ b/roles/console/files/certbot-renew-eucaconsole.conf
@@ -1,3 +1,0 @@
-[Service]
-EnvironmentFile=
-Environment="DEPLOY_HOOK=--deploy-hook /usr/bin/eucaconsole-reload-https --deploy-hook /usr/local/bin/eucalyptus-cloud-https-import" "CERTBOT_ARGS=--cert-name eucaconsole"

--- a/roles/console/tasks/certbot.yml
+++ b/roles/console/tasks/certbot.yml
@@ -8,22 +8,6 @@
   tags:
     - packages
 
-- name: certbot-renew service.d directory
-  file:
-    path: /etc/systemd/system/certbot-renew.service.d
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-
-- name: eucaconsole certbot-renew configuration drop-in
-  copy:
-    src: certbot-renew-eucaconsole.conf
-    dest: /etc/systemd/system/certbot-renew.service.d/certbot-renew-eucaconsole.conf
-    owner: root
-    group: root
-    mode: 0644
-
 - name: certbot configuration to issue for service endpoints
   set_fact:
     eucaconsole_certbot_domain: "{{ eucaconsole_certbot_domain }},{{ eucaconsole_certbot_services | map('regex_replace', '^(.*)$', '\\1.' + cloud_system_dns_dnsdomain) | list | unique | sort | join(',') }}"
@@ -32,14 +16,19 @@
 - name: eucaconsole certbot https
   shell: |
     set -eu
-    CONSOLE_DOMAIN={{ eucaconsole_certbot_domain | quote }}
-    REGISTRATION_EMAIL={{ eucaconsole_certbot_email | quote }}
-    EXTRA_OPTS={{ eucaconsole_certbot_certonly_opts | quote }}
+    CONSOLE_DOMAIN="{{ eucaconsole_certbot_domain | quote }}"
+    REGISTRATION_EMAIL="{{ eucaconsole_certbot_email | quote }}"
+    EXTRA_OPTS="{{ eucaconsole_certbot_certonly_opts | quote }}"
     if [ -z "${REGISTRATION_EMAIL}" ] ; then
       EXTRA_OPTS="${EXTRA_OPTS} --register-unsafely-without-email"
     else
       EXTRA_OPTS="${EXTRA_OPTS} --email ${REGISTRATION_EMAIL}"
     fi
+    if [ "{{ 'true' if eucaconsole_certbot_request_service_domains else 'false' }}" = "true" ] ; then
+      EXTRA_OPTS="${EXTRA_OPTS} --deploy-hook /usr/local/bin/eucalyptus-cloud-https-import"
+    fi
+    ln -s -f -T /etc/letsencrypt/live/eucaconsole/fullchain.pem /etc/pki/tls/certs/eucaconsole.crt
+    ln -s -f -T /etc/letsencrypt/live/eucaconsole/privkey.pem /etc/pki/tls/private/eucaconsole.key
     certbot certonly \
       --non-interactive \
       --agree-tos \
@@ -47,11 +36,10 @@
       --domain "${CONSOLE_DOMAIN}" \
       --webroot \
       --webroot-path /var/lib/eucaconsole/well-known-root/ \
+      --deploy-hook /usr/bin/eucaconsole-reload-https \
       ${EXTRA_OPTS}
-    ln -s -f -T /etc/letsencrypt/live/eucaconsole/fullchain.pem /etc/pki/tls/certs/eucaconsole.crt
-    ln -s -f -T /etc/letsencrypt/live/eucaconsole/privkey.pem /etc/pki/tls/private/eucaconsole.key
-    eucaconsole-reload-https
-    eucalyptus-cloud-https-import
+  args:
+    creates: /etc/letsencrypt/live/eucaconsole/fullchain.pem
 
 - name: eucaconsole certbot https renewal
   systemd:
@@ -63,6 +51,6 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    euctl euctl bootstrap.webservices.ssl.server_alias=eucaconsole
+    euctl bootstrap.webservices.ssl.server_alias=eucalyptus-cloud
   delegate_to: "{{ groups.cloud[0] }}"
   when: eucaconsole_certbot_request_service_domains and cloud_system_dns_dnsdomain

--- a/roles/console/tasks/main.yml
+++ b/roles/console/tasks/main.yml
@@ -67,19 +67,5 @@
     state: started
     name: eucaconsole
 
-- name: configure eucalyptus/admin password
-  shell: |
-    set -eu
-    eval $(clcadmin-assume-system-credentials)
-    CONSOLE_PASSWORD={{ eucaconsole_admin_password | quote }}
-    euare-useraddloginprofile -u admin -p "${CONSOLE_PASSWORD}"
-  delegate_to: "{{ groups.cloud[0] }}"
-  register: shell_result
-  when: eucaconsole_admin_password|length >= 8
-  changed_when: '"EntityAlreadyExists" not in shell_result.stderr'
-  failed_when:
-    - shell_result.rc != 0
-    - '"EntityAlreadyExists" not in shell_result.stderr'
-
 - import_tasks: certbot.yml
   when: eucaconsole_certbot_configure

--- a/roles/none/tasks/main.yml
+++ b/roles/none/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
 # Remove eucalyptus packages and configuration (including dependencies)
+- name: disable eucaconsole service
+  systemd:
+    enabled: false
+    state: stopped
+    name: eucaconsole
+  register: systemd_result
+  failed_when: "systemd_result is failed and 'Could not find the requested service' not in systemd_result.msg"
+
 - name: disable eucalyptus-cloud service
   systemd:
     enabled: false
@@ -153,6 +161,17 @@
     path: /etc/eucalyptus
     state: absent
 
+- name: remove eucalyptus local bin scripts
+  file:
+    path: "/usr/local/bin/{{ item }}"
+    state: absent
+  loop:
+  - "console-manage-stack"
+  - "eucalyptus-cloud-https-import"
+  - "eucalyptus-images"
+  - "eucalyptus-system-images"
+  - "eucalyptus-vpcmidotz-up.sh"
+
 - name: remove eucalyptus libexec directory
   file:
     path: /usr/libexec/eucalyptus
@@ -263,6 +282,11 @@
 - name: remove tools configuration directory
   file:
     path: /root/.euca
+    state: absent
+
+- name: remove aws tools configuration directory
+  file:
+    path: /root/.aws
     state: absent
 
 - name: remove eucalyptus deployment configuration directory


### PR DESCRIPTION
Support for deploying the console as a cloudformation stack and for using certbot with the eucalyptus-cloud service via route53 dns domain authentication.

New scripts are added as needed:

* `eucalyptus-system-images` : check and install system images (console, service)
* `console-manage-stack` : check, create, and delete a cloudformation stack for the console

The console management command uses a new configuration file `/etc/eucalyptus/console.conf` for stack parameters. The stack is deployed in a new `console` account.

The password for eucalyptus/admin is now set using `cloud_admin_password` as is useful either when deploying the console as a stack or directly on a host.

CloudFormation templates are added under `/var/lib/eucalyptus/templates/`.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=474
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/30/
Test: /job/eucalyptus-5-qa-fast/66/