### PR TITLE
Remove systemd units and drop-ins on clean

### DIFF
--- a/roles/cloud/tasks/vpcmido.yml
+++ b/roles/cloud/tasks/vpcmido.yml
@@ -37,13 +37,6 @@
     mode: 0644
   when: vpcmido_gw_srv_veth_create
 
-- name: start eucalyptus midonet gateway veth service
-  systemd:
-    enabled: true
-    state: started
-    name: eucalyptus-vpcmido-gwnet
-  when: vpcmido_gw_srv_veth_create
-
 - name: eucalyptus midonet gateway proxy arp runtime
   command:
     cmd: sysctl -w net/ipv4/conf/{{ cloud_firewalld_public_interface }}/proxy_arp=1
@@ -128,9 +121,32 @@
   tags:
     - image
 
+- name: eucanetd service.d directory
+  file:
+    path: /etc/systemd/system/eucanetd.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: eucanetd tunnel zone configuration drop-in
+  copy:
+    src: eucanetd-vpcmidotz.conf
+    dest: /etc/systemd/system/eucanetd.service.d/eucanetd-vpcmidotz.conf
+    owner: root
+    group: root
+    mode: 0644
+
 - name: systemd daemon reload
   systemd:
     daemon_reload: true
+
+- name: start eucalyptus midonet gateway veth service
+  systemd:
+    enabled: true
+    state: started
+    name: eucalyptus-vpcmido-gwnet
+  when: vpcmido_gw_srv_veth_create
 
 - name: eucalyptus firewalld midonet gateway service
   template:
@@ -199,22 +215,6 @@
     owner: root
     group: root
     mode: 0755
-
-- name: eucanetd service.d directory
-  file:
-    path: /etc/systemd/system/eucanetd.service.d
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-
-- name: eucanetd tunnel zone configuration drop-in
-  copy:
-    src: eucanetd-vpcmidotz.conf
-    dest: /etc/systemd/system/eucanetd.service.d/eucanetd-vpcmidotz.conf
-    owner: root
-    group: root
-    mode: 0644
 
 - name: start midonet-cluster service
   systemd:

--- a/roles/none/tasks/main.yml
+++ b/roles/none/tasks/main.yml
@@ -143,6 +143,20 @@
       - python-rados
     state: absent
 
+- name: remove systemd units and drop-ins
+  file:
+    path: "/etc/systemd/system/{{ item }}"
+    state: absent
+  loop:
+  - "cassandra.service.d"
+  - "ceph-osd@.service.d"
+  - "certbot-renew.service.d"
+  - "eucalyptus-vpcmido-gwnet.service"
+  - "eucanetd.service.d"
+  - "midolman.service.d"
+  - "midonet-cluster.service.d"
+  - "zookeeper.service.d"
+
 - name: remove eucaconsole configuration directory
   file:
     path: /etc/eucaconsole
@@ -270,3 +284,6 @@
     path: /root/eucalyptus
     state: absent
 
+- name: systemd daemon reload
+  systemd:
+    daemon_reload: true


### PR DESCRIPTION
The clean playbook should remove systemd changes from a deployment.

This pull request also fixes an issue where system reload was not occurring after units were modified on install. This issue was previously hidden as we did not remove the configuration on clean.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=489
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/38/
Test: /job/eucalyptus-5-qa-fast/71/

Demo is that clean removes systemd files:

```
# 
# 
# yum install eucalyptus-ansible
...
Installed:
  eucalyptus-ansible.noarch 0:5.0.100-0.107.anssysdcln2.el7                                                                                                                                   
...
# 
# 
# ansible-playbook -i inventory.yml /usr/share/eucalyptus-ansible/playbook_clean.yml
...
...
# 
# 
# find /etc/systemd/system/ -type f
# 
# 
```