### PR TITLE
Firewalld cluster zone should allow gre traffic

### DIFF
--- a/roles/ceph-common/files/firewalld-service-euca-gre.xml
+++ b/roles/ceph-common/files/firewalld-service-euca-gre.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <protocol value="gre"/>
+  <module name="nf_conntrack_proto_gre"/>
+</service>

--- a/roles/ceph-common/tasks/base_firewall.yml
+++ b/roles/ceph-common/tasks/base_firewall.yml
@@ -29,6 +29,17 @@
     - firewalld
   when: cloud_firewalld_cluster_interface is not none and cloud_firewalld_cluster_zone is not none
 
+- name: eucalyptus gre service
+  copy:
+    src: firewalld-service-euca-gre.xml
+    dest: /etc/firewalld/services/euca-gre.xml
+    owner: root
+    group: root
+    mode: 0644
+  tags:
+    - firewalld
+  when: cloud_firewalld_cluster_cidr is not none
+
 - name: eucalyptus firewalld cluster zone
   template:
     src: firewalld-zone-euca-cluster.xml.j2

--- a/roles/ceph-common/templates/firewalld-zone-euca-cluster.xml.j2
+++ b/roles/ceph-common/templates/firewalld-zone-euca-cluster.xml.j2
@@ -11,4 +11,8 @@
     <port protocol="udp" port="0-65535"/>
     <accept/>
   </rule>
+  <rule family="ipv4">
+    <service name="euca-gre"/>
+    <accept/>
+  </rule>
 </zone>


### PR DESCRIPTION
Add firewalld configuration allowing gre traffic within the cluster.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=490
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/39/
Test: /job/eucalyptus-5-qa-suite/180/

The demo is that instances accessible with the firewall enabled in multi-host qa deployments.