### PR TITLE
Configure listen interface when using tgtd

### DIFF
--- a/roles/zone/tasks/main.yml
+++ b/roles/zone/tasks/main.yml
@@ -42,6 +42,23 @@
     mode: 0644
   when: eucalyptus_ceph_keyring is defined
 
+- name: tgtd systemd drop-in directory
+  file:
+    path: /etc/systemd/system/tgtd.service.d
+    state: directory
+    mode: 0755
+  when: eucalyptus_ceph_conf is undefined
+
+- name: tgtd systemd drop-in for listening on cluster interface
+  copy:
+    dest: /etc/systemd/system/tgtd.service.d/override.conf
+    mode: 0644
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/sbin/tgtd -f --iscsi "portal={{ eucalyptus_host_cluster_ipv4 | quote }}:3260" $TGTD_OPTS
+  when: eucalyptus_ceph_conf is undefined
+
 - name: start tgtd service
   systemd:
     enabled: true


### PR DESCRIPTION
For `das` or `overlay` storage we now configure `tgtd` to listen only on the cluster interface.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=524
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/53/
Test: /job/eucalyptus-5-qa-suite/182/

Demo is that the listener uses the cluster interface:

```
# 
# euserv-describe-services --filter service-type=storage
SERVICE  storage  cloud-1a  storage.10.117.111.18  enabled  
# 
# 
# ss -ntlp | grep tgtd
LISTEN     0      128    10.117.111.18:3260                     *:*                   users:(("tgtd",pid=1335,fd=6))
# 
# 
```

so `10.117.111.18` rather than `0.0.0.0`.