### PR TITLE
Remove image tag for systemd dnsmasq task

### DIFF
--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -55,8 +55,6 @@
     enabled: false
     state: stopped
     name: dnsmasq
-  tags:
-    - image
 
 - name: ceph configuration directory
   file:


### PR DESCRIPTION
Remove image tag from `systemd` task. Image builds should not assume systemd is running.