### PR TITLE
MinIO objectstorage role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -13,6 +13,10 @@
   roles:
   - ceph
 
+- hosts: minio
+  roles:
+  - minio
+
 - hosts: node
   tasks:
   - name: eucalyptus node host facts

--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -184,7 +184,7 @@
   register: shell_result
   until: shell_result.rc == 0
   retries: 5
-  when: eucalyptus_ceph_conf is undefined
+  when: eucalyptus_ceph_conf is undefined and eucalyptus_minio_endpoint is undefined
 
 - name: configure cloud properties
   shell: |
@@ -213,7 +213,21 @@
     set -eu
     eval $(clcadmin-assume-system-credentials)
     euctl objectstorage.providerclient=walrus
-  when: eucalyptus_ceph_conf is undefined
+  when: eucalyptus_ceph_conf is undefined and eucalyptus_minio_endpoint is undefined
+  register: shell_result
+  until: shell_result.rc == 0
+  retries: 5
+
+- name: configure cloud storage properties for minio
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euctl objectstorage.s3provider.s3endpoint="{{ eucalyptus_minio_endpoint | quote }}"
+    euctl objectstorage.s3provider.s3accesskey="{{ eucalyptus_minio_creds.access_key | quote }}"
+    euctl objectstorage.s3provider.s3secretkey="{{ eucalyptus_minio_creds.secret_key | quote }}"
+    euctl objectstorage.s3provider.s3endpointheadresponse=400
+    euctl objectstorage.providerclient=minio
+  when: eucalyptus_ceph_conf is undefined and eucalyptus_minio_endpoint is defined
   register: shell_result
   until: shell_result.rc == 0
   retries: 5
@@ -222,9 +236,9 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    euctl objectstorage.s3provider.s3endpoint={{ eucalyptus_ceph_rgw_endpoint | quote }}
-    euctl objectstorage.s3provider.s3accesskey={{ eucalyptus_ceph_rgw_creds.access_key | quote }}
-    euctl objectstorage.s3provider.s3secretkey={{ eucalyptus_ceph_rgw_creds.secret_key | quote }}
+    euctl objectstorage.s3provider.s3endpoint="{{ eucalyptus_ceph_rgw_endpoint | quote }}"
+    euctl objectstorage.s3provider.s3accesskey="{{ eucalyptus_ceph_rgw_creds.access_key | quote }}"
+    euctl objectstorage.s3provider.s3secretkey="{{ eucalyptus_ceph_rgw_creds.secret_key | quote }}"
     euctl objectstorage.s3provider.s3endpointheadresponse=200
     euctl objectstorage.providerclient=ceph-rgw
   when: eucalyptus_ceph_conf is defined

--- a/roles/minio/defaults/main.yml
+++ b/roles/minio/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# MinIO settings
+minio_endpoint: "{{ hostvars[groups['minio'][0]]['eucalyptus_host_cluster_ipv4'] }}:{{ minio_port }}"
+minio_port: 9000
+minio_data_path: /var/lib/minio/data

--- a/roles/minio/files/minio.service
+++ b/roles/minio/files/minio.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=MinIO
+Wants=network-online.target
+After=network-online.target
+AssertFileIsExecutable=/opt/minio/bin/minio
+AssertPathExists=/etc/sysconfig/minio
+
+[Service]
+WorkingDirectory=/opt/minio/
+EnvironmentFile=/etc/sysconfig/minio
+EnvironmentFile=/etc/sysconfig/minio-key
+ExecStartPre=/bin/bash -c "if [ -z \"${MINIO_VOLUMES}\" ]; then echo \"Variable MINIO_VOLUMES not set in /etc/sysconfig/minio\"; exit 1; fi"
+ExecStart=/opt/minio/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=full
+Restart=on-failure
+LimitNOFILE=65536
+TimeoutStopSec=infinity
+SendSIGKILL=no
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/minio/meta/main.yml
+++ b/roles/minio/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+- role: ceph-common
+  vars:
+    ceph_facts: no

--- a/roles/minio/tasks/main.yml
+++ b/roles/minio/tasks/main.yml
@@ -1,0 +1,116 @@
+---
+- name: minio application directory
+  file:
+    path: /opt/minio
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  tags:
+    - image
+
+- name: minio bin directory
+  file:
+    path: /opt/minio/bin
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  tags:
+    - image
+
+- name: minio config directory
+  file:
+    path: /opt/minio/etc
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  tags:
+    - image
+
+- name: minio certificates directory
+  file:
+    path: /opt/minio/etc/certs
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  tags:
+    - image
+
+- name: minio data directory
+  file:
+    path: /var/lib/minio
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  tags:
+    - image
+
+- name: download minio binary
+  get_url:
+    url: https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2020-10-03T02-19-42Z
+    dest: /opt/minio/bin/minio
+    checksum: sha256:d8164b0446c79fc80f5d3a06971fa87fa0ede519c6d253f260fbfba7aa834a0b
+    mode: 0555
+  tags:
+    - image
+
+- name: download mc binary
+  get_url:
+    url: https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2020-10-03T02-54-56Z
+    dest: /opt/minio/bin/mc
+    checksum: sha256:59e184bd4e2c3a8a19837b0f0da3977bd4e301495a24e4a5d50e291728a1de51
+    mode: 0555
+  tags:
+    - image
+
+- name: minio systemd service
+  copy:
+    src: minio.service
+    dest: /etc/systemd/system/minio.service
+    owner: root
+    group: root
+    mode: 0644
+  tags:
+    - image
+
+- name: minio environment service configuration
+  template:
+    src: minio.j2
+    dest: /etc/sysconfig/minio
+    owner: root
+    group: root
+    mode: 0644
+
+- name: minio environment service secrets configuration
+  template:
+    src: minio-key.j2
+    dest: /etc/sysconfig/minio-key
+    force: no
+    owner: root
+    group: root
+    mode: 0600
+
+- name: minio secrets
+  slurp:
+    path: /etc/sysconfig/minio-key
+  register: slurp_result
+
+- name: start minio service
+  systemd:
+    daemon_reload: true
+    enabled: true
+    state: started
+    name: minio
+
+- name: minio secrets facts
+  set_fact: "eucalyptus_minio_creds_internal={{ ('{' + (slurp_result.content | b64decode).split('\n') | select | map('regex_replace', '([^=]*)=(.*)', '\"\\1\": \"\\2\"') | join(',') + '}') | from_json }}"
+
+- name: minio configuration facts
+  set_fact:
+    eucalyptus_minio_creds: "{{ {'access_key': eucalyptus_minio_creds_internal.MINIO_ACCESS_KEY, 'secret_key': eucalyptus_minio_creds_internal.MINIO_SECRET_KEY } }}"
+    eucalyptus_minio_endpoint: "{{ minio_endpoint }}"
+

--- a/roles/minio/templates/minio-key.j2
+++ b/roles/minio/templates/minio-key.j2
@@ -1,0 +1,2 @@
+MINIO_ACCESS_KEY=AKIM{{ lookup('password', 'credentials/objectstorage/minio/access_key length=17 chars=ascii_uppercase,2,3,4,5,6,7') }}
+MINIO_SECRET_KEY={{ lookup('password', 'credentials/objectstorage/minio/secret_key length=40 chars=ascii_letters,digits') }}

--- a/roles/minio/templates/minio.j2
+++ b/roles/minio/templates/minio.j2
@@ -1,0 +1,3 @@
+MINIO_BROWSER=off
+MINIO_OPTS=--address {{ eucalyptus_host_cluster_ipv4 }}:{{ minio_port }} --config-dir /opt/minio/etc --certs-dir /opt/minio/etc/certs
+MINIO_VOLUMES={% for minio in groups.minio %}http://{{ hostvars[minio].eucalyptus_host_cluster_ipv4 }}:{{ minio_port }}{{ minio_data_path }}{1...4} {% endfor %}

--- a/roles/none/tasks/main.yml
+++ b/roles/none/tasks/main.yml
@@ -88,6 +88,14 @@
   register: systemd_result
   failed_when: "systemd_result is failed and 'Could not find the requested service' not in systemd_result.msg"
 
+- name: stop minio service
+  systemd:
+    enabled: false
+    state: stopped
+    name: minio
+  register: systemd_result
+  failed_when: "systemd_result is failed and 'Could not find the requested service' not in systemd_result.msg"
+
 - name: remove eucalyptus and dependency packages
   yum:
     name:
@@ -163,6 +171,7 @@
   - "eucanetd.service.d"
   - "midolman.service.d"
   - "midonet-cluster.service.d"
+  - "minio.service"
   - "zookeeper.service.d"
 
 - name: remove eucaconsole configuration directory
@@ -291,6 +300,24 @@
 - name: remove ceph-deploy user conf file
   file:
     path: /home/ceph-deploy/.cephdeploy.conf
+    state: absent
+
+- name: remove minio configuration
+  file:
+    path: "/etc/sysconfig/{{ item }}"
+    state: absent
+  loop:
+  - "minio"
+  - "minio-key"
+
+- name: remove minio application directory
+  file:
+    path: /opt/minio
+    state: absent
+
+- name: remove minio data directory
+  file:
+    path: /var/lib/minio
     state: absent
 
 - name: remove tools configuration directory


### PR DESCRIPTION
Support for configuration of MinIO as the objectstorage provider. To use, specify hosts in a `minio` group in the inventory.

For example:

```
  children:
    minio:
      hosts:
        192.168.123.10:
    cloud:
      hosts:
        192.168.123.10:
    node:
      hosts:
        192.168.123.20:
```

which would deploy and use mino on a single host which also runs the cloud controller.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=548
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/60/
Test: /job/eucalyptus-5-qa-fast/86/

Demo is that tests pass when running MinIO and walrus is not deployed:

```
# 
# rpm -q eucalyptus
eucalyptus-5.0.0-0.124.ansmin.el7.x86_64
# 
# 
# euserv-describe-services | grep walrus
# 
# 
# euctl objectstorage.providerclient objectstorage.s3provider
objectstorage.providerclient = minio
objectstorage.s3provider.s3accesskey = ********
objectstorage.s3provider.s3endpoint = 10.117.111.14:9000
objectstorage.s3provider.s3endpointheadresponse = 400
objectstorage.s3provider.s3secretkey = ********
objectstorage.s3provider.s3usebackenddns = false
objectstorage.s3provider.s3usehttps = false
# 
# 
```