### PR TITLE
Ceph configuration for osd pool pg_num

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -11,6 +11,8 @@ ceph_osd_volume_pool: eucavolumes
 
 ceph_osd_snapshot_pool: eucasnapshots
 
+ceph_osd_pool_pgnum: 16
+
 ceph_rgw_uid: eucas3
 
 ceph_facts: "{{ True if (ceph_facts_local or ('ceph' in groups and groups['ceph'])) else False }}"

--- a/roles/ceph/tasks/ceph_eucalyptus.yml
+++ b/roles/ceph/tasks/ceph_eucalyptus.yml
@@ -17,5 +17,5 @@
     EUCA_CEPH_RGW_UID: "{{ ceph_rgw_uid }}"
     EUCA_CEPH_SNAPSHOT_POOL_NAME: "{{ ceph_osd_snapshot_pool }}"
     EUCA_CEPH_VOLUME_POOL_NAME: "{{ ceph_osd_volume_pool }}"
-    EUCA_POOL_PLACEMENT_GROUPS: 60
+    EUCA_POOL_PLACEMENT_GROUPS: "{{ ceph_osd_pool_pgnum }}"
 

--- a/roles/ceph/tasks/ceph_install_deploy.yml
+++ b/roles/ceph/tasks/ceph_install_deploy.yml
@@ -13,6 +13,14 @@
       osd_pool_default_min_size = 1
   when: groups.ceph|length < 3
 
+- name: ceph custom configuration for osds
+  blockinfile:
+    path: /home/ceph-deploy/cluster/ceph.conf
+    marker: '# {mark} eucalyptus ceph osd general configuration'
+    block: |
+      osd_pool_default_pg_num = {{ ceph_osd_pool_pgnum }}
+      osd_pool_default_pgp_num = {{ ceph_osd_pool_pgnum }}
+
 - name: ceph custom configuration for rgw frontends
   blockinfile:
     path: /home/ceph-deploy/cluster/ceph.conf


### PR DESCRIPTION
Ceph `pg_num` for eucalyptus pools is reduced from 60 to 16 and is now configurable as `ceph_osd_pool_pgnum`. The configured value is also used to set the default pgnum which is used with ceph rgw. The smaller size works with a 3 host cluster and a larger value could be used when more osds are present.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=579
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/74/
Test: /job/eucalyptus-5-qa-fast/89/

The demo is that the new values are used:

```
# cat /etc/ceph/ceph.conf 
[global]
fsid = d4d5e705-fc35-4547-80b2-bfe5d9f52bf7
public_network = 10.117.0.0/17
cluster_network = 10.117.0.0/17
mon_initial_members = nc38, nc39, nc40
mon_host = 10.117.111.48,10.117.111.49,10.117.111.50
auth_cluster_required = cephx
auth_service_required = cephx
auth_client_required = cephx

# BEGIN eucalyptus ceph osd general configuration
osd_pool_default_pg_num = 16
osd_pool_default_pgp_num = 16
# END eucalyptus ceph osd general configuration
...
```

and that objectstorage is now functional when deployed using a ceph cluster.