### PR TITLE
Cloud role eucanetd systemd namespace drop-in

### DIFF
--- a/roles/cloud/files/eucanetd-no-mount-ns.conf
+++ b/roles/cloud/files/eucanetd-no-mount-ns.conf
@@ -1,0 +1,6 @@
+# Disable service file system namespace to allow network namespace use
+# on the cloud controller, e.g.: ip netns exec vpc-... ping 172.31...
+[Service]
+PrivateTmp=false
+ProtectHome=false
+ProtectSystem=false

--- a/roles/cloud/tasks/vpcmido.yml
+++ b/roles/cloud/tasks/vpcmido.yml
@@ -137,6 +137,14 @@
     group: root
     mode: 0644
 
+- name: eucanetd filesystem namespace configuration drop-in
+  copy:
+    src: eucanetd-no-mount-ns.conf
+    dest: /etc/systemd/system/eucanetd.service.d/eucanetd-no-mount-ns.conf
+    owner: root
+    group: root
+    mode: 0644
+
 - name: systemd daemon reload
   systemd:
     daemon_reload: true


### PR DESCRIPTION
The cloud role is updated to deploy a systemd service drop-in that disables file system protection. This protection is still active when eucanetd is running on node controllers but is now disabled on the cloud controller for compatibility with network namespaces.

The demo is that the expected file (`/etc/systemd/system/eucanetd.service.d/eucanetd-no-mount-ns.conf`) is present and there are no errors listing network namespaces on the host:

```
# ip netns list
vpc-a1d918361059cdedc (id: 2)
vpc-931ee08517b34c067 (id: 1)
vpc-1c2dffa277950c234 (id: 0)
```