### PR TITLE
Cloud role eucalyptus-account utility

### DIFF
--- a/roles/cloud/files/eucalyptus-account
+++ b/roles/cloud/files/eucalyptus-account
@@ -1,0 +1,156 @@
+#!/bin/sh
+# Eucalyptus cloud account resources utility
+set -euo pipefail
+
+# Process command
+ACCOUNT_USAGE="Usage:\n\n\teucalyptus-account [clean|list] --account (ACCOUNT_ID|ACCOUNT_ALIAS)\n"
+ACCOUNT_COMAND=""
+ACCOUNT_SPECIFIER=""
+while (( "$#" )); do
+  ACCOUNT_ARG="$1"
+  case "${ACCOUNT_ARG}" in
+    --account)
+      shift
+      ACCOUNT_SPECIFIER="$1"
+      ;;
+    *)
+      if [ -z "${ACCOUNT_COMAND}" ] ; then
+        ACCOUNT_COMAND="${ACCOUNT_ARG}"
+      else
+        echo -e "${ACCOUNT_USAGE}"
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [ "${ACCOUNT_COMAND}" != "clean" ] && [ "${ACCOUNT_COMAND}" != "list" ] ; then
+  echo -e "${ACCOUNT_USAGE}"
+  exit 1
+elif [ -z "${ACCOUNT_SPECIFIER}" ] ; then
+  echo -e "${ACCOUNT_USAGE}"
+  exit 1
+fi
+
+function cleancommand {
+  [ "${ACCOUNT_COMAND}" != "clean" ] || "$@" || true
+}
+
+ACTION_DESCRIPTION="DELETE "
+[ "${ACCOUNT_COMAND}" = "clean" ] || ACTION_DESCRIPTION=""
+
+# Act as account
+eval $("/usr/sbin/clcadmin-release-credentials")
+ACT_AS_COMMANDS=$("/usr/sbin/clcadmin-impersonate-user" -a "${ACCOUNT_SPECIFIER}")
+eval "${ACT_AS_COMMANDS}"
+eval $("/usr/bin/euca-generate-environment-config")
+
+IFS=$'\t'
+
+# CloudFormation stacks
+for STACK_NAME in $(aws cloudformation describe-stacks --query "Stacks[].StackName" --output text); do
+  echo "${ACTION_DESCRIPTION}STACK ${STACK_NAME}"
+  cleancommand aws cloudformation delete-stack --stack-name "${STACK_NAME}"
+done
+
+# S3 buckets
+for BUCKET_NAME in $(aws s3api list-buckets --query "Buckets[].Name" --output text); do
+  echo "${ACTION_DESCRIPTION}BUCKET ${BUCKET_NAME}"
+  cleancommand aws s3 rb --force "s3://${BUCKET_NAME}"
+done
+
+# Cloudwatch alarms
+for ALARM_NAME in $(aws cloudwatch describe-alarms --query "MetricAlarms[].AlarmName" --output text); do
+  echo "${ACTION_DESCRIPTION}ALARM ${ALARM_NAME}"
+  cleancommand aws cloudwatch delete-alarms --alarm-names "${ALARM_NAME}"
+done
+
+# Elastic load balancers
+for ELB_NAME in $(aws elb describe-load-balancers --query "LoadBalancerDescriptions[].LoadBalancerName" --output text); do
+  echo "${ACTION_DESCRIPTION}ELB ${ELB_NAME}"
+  cleancommand aws elb delete-load-balancer --load-balancer-name "${ELB_NAME}"
+done
+
+# AutoScaling groups, and launch configurations
+for GROUP_NAME in $(aws autoscaling describe-auto-scaling-groups --query "AutoScalingGroups[].AutoScalingGroupName" --output text); do
+  echo "${ACTION_DESCRIPTION}ASGROUP ${GROUP_NAME}"
+  cleancommand aws autoscaling delete-auto-scaling-group --auto-scaling-group-name "${GROUP_NAME}"
+done
+
+for CONFIG_NAME in $(aws autoscaling describe-launch-configurations --query "LaunchConfigurations[].LaunchConfigurationName" --output text); do
+  echo "${ACTION_DESCRIPTION}ASCONFIG ${CONFIG_NAME}"
+  cleancommand aws autoscaling delete-launch-configuration --launch-configuration-name "${CONFIG_NAME}"
+done
+
+# EC2 images, snapshots, instances, volumes, keypairs, security groups, and elastic ips
+for IMAGE_ID in $(aws ec2 describe-images --owners self --query "Images[].ImageId" --output text); do
+  echo "${ACTION_DESCRIPTION}IMAGE ${IMAGE_ID}"
+  cleancommand aws ec2 deregister-image --image-id "${IMAGE_ID}"
+done
+
+for SNAPSHOT_ID in $(aws ec2 describe-snapshots --owner-ids self --query "Snapshots[].SnapshotId" --output text); do
+  echo "${ACTION_DESCRIPTION}SNAPSHOT ${SNAPSHOT_ID}"
+  cleancommand aws ec2 delete-snapshot --snapshot-id "${SNAPSHOT_ID}"
+done
+
+for INSTANCE_ID in $(aws ec2 describe-instances --filter "Name=instance-state-name,Values=[pending,running,stopped,stopping]" --query "Reservations[].Instances[].InstanceId" --output text); do
+  echo "${ACTION_DESCRIPTION}INSTANCE ${INSTANCE_ID}"
+  cleancommand aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}"
+done
+
+for VOLUME_ID in $(aws ec2 describe-volumes --query "Volumes[].VolumeId" --output text); do
+  echo "${ACTION_DESCRIPTION}VOLUME ${VOLUME_ID}"
+  cleancommand aws ec2 delete-volume --volume-id "${VOLUME_ID}"
+done
+
+for NETWORK_INTERFACE_ID in $(aws ec2 describe-network-interfaces --query "NetworkInterfaces[].NetworkInterfaceId" --output text); do
+  echo "${ACTION_DESCRIPTION}NETINTERFACE ${NETWORK_INTERFACE_ID}"
+  cleancommand aws ec2 delete-network-interface --network-interface-id "${NETWORK_INTERFACE_ID}"
+done
+
+for SECURITY_GROUP_ID in $(aws ec2 describe-security-groups --query "SecurityGroups[?GroupName!='default'].GroupId" --output text); do
+  echo "${ACTION_DESCRIPTION}SECGROUP ${SECURITY_GROUP_ID}"
+  cleancommand aws ec2 delete-security-group --group-id "${SECURITY_GROUP_ID}"
+done
+
+for NETWORK_ACL_ID in $(aws ec2 describe-network-acls --filter Name=default,Values=false --query "NetworkAcls[].NetworkAclId" --output text); do
+  echo "${ACTION_DESCRIPTION}NETACL ${NETWORK_ACL_ID}"
+  cleancommand aws ec2 delete-network-acl --network-acl-id "${NETWORK_ACL_ID}"
+done
+
+for ROUTE_TABLE_ID in $(aws ec2 describe-route-tables --filter Name=association.main,Values=false --query "RouteTables[].RouteTableId" --output text); do
+  echo "${ACTION_DESCRIPTION}ROUTETBL ${ROUTE_TABLE_ID}"
+  cleancommand aws ec2 delete-route-table --route-table-id "${ROUTE_TABLE_ID}"
+done
+
+for NAT_GATEWAY_ID in $(aws ec2 describe-nat-gateways --filter Name=state,Values=available --query "NatGateways[].NatGatewayId" --output text); do
+  echo "${ACTION_DESCRIPTION}NATGATEWAY ${NAT_GATEWAY_ID}"
+  cleancommand aws ec2 delete-nat-gateway --nat-gateway-id "${NAT_GATEWAY_ID}"
+done
+
+for INTERNET_GATEWAY_ID in $(aws ec2 describe-internet-gateways --query "InternetGateways[].InternetGatewayId" --output text); do
+  echo "${ACTION_DESCRIPTION}NETGATEWAY ${INTERNET_GATEWAY_ID}"
+  cleancommand aws ec2 delete-internet-gateway --internet-gateway-id "${INTERNET_GATEWAY_ID}"
+done
+
+for SUBNET_ID in $(aws ec2 describe-subnets --query "Subnets[].SubnetId" --output text); do
+  echo "${ACTION_DESCRIPTION}SUBNET ${SUBNET_ID}"
+  cleancommand aws ec2 delete-subnet --subnet-id "${SUBNET_ID}"
+done
+
+for VPC_ID in $(aws ec2 describe-vpcs --query "Vpcs[].VpcId" --output text); do
+  echo "${ACTION_DESCRIPTION}VPC ${VPC_ID}"
+  cleancommand aws ec2 delete-vpc --vpc-id "${VPC_ID}"
+done
+
+for ELASTIC_IP in $(aws ec2 describe-addresses --query "Addresses[].PublicIp" --output text); do
+  echo "${ACTION_DESCRIPTION}EIP ${ELASTIC_IP}"
+  cleancommand aws ec2 release-address --public-ip "${ELASTIC_IP}"
+done
+
+for KEYPAIR_NAME in $(aws ec2 describe-key-pairs --query "KeyPairs[].KeyName" --output text); do
+  echo "${ACTION_DESCRIPTION}KEYPAIR ${KEYPAIR_NAME}"
+  cleancommand aws ec2 delete-key-pair --key-name "${KEYPAIR_NAME}"
+done
+

--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -242,6 +242,14 @@
   until: shell_result.rc == 0
   retries: 5
 
+- name: eucalyptus-account account resources utility
+  copy:
+    src: eucalyptus-account
+    dest: /usr/local/bin/eucalyptus-account
+    owner: root
+    group: root
+    mode: 0755
+
 - name: eucalyptus-images image install wrapper
   copy:
     src: eucalyptus-images


### PR DESCRIPTION
The cloud role now includes a `eucalyptus-account` utility script that can be used to list/clean resources (images, instances, etc) for an account. This could be used for resource clean up prior to account deletion.

The demo is that the script is installed:

```
# eucalyptus-account list --account eucalyptus
BUCKET centos-7-x86-64-genericcloud
BUCKET eucalyptus-service-image-v5.0.100
IMAGE emi-668631ba77965d272
IMAGE emi-ffdc2689748b86321
SECGROUP sg-3d848a6bd04449bc9
NETGATEWAY igw-11e92f64a7897b9e1
SUBNET subnet-08847a87cd819ece3
VPC vpc-05d9a508044b813db
```