### PR TITLE
Cloud role web services listener default cidr

### DIFF
--- a/roles/cloud/defaults/main.yml
+++ b/roles/cloud/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Cloud settings
 cloud_region_region_name: "{{ cloud_region_name }}"
-cloud_listener_cidr: 0.0.0.0/0
+cloud_listener_cidr: 0.0.0.0/32
 cloud_listener_port: "{{ cloud_public_port }}"
 cloud_public_port: 8773
 cloud_properties: {}


### PR DESCRIPTION
The web services listener cidr should default to `0.0.0.0/32`, using `0.0.0.0/0` causes errors to be logged due to matching every interface and the any address:

```
Wed Nov 11 20:03:21 2020  INFO [WebServices:web-services-restarter-680] Starting web services listeners on /0.0.0.0,/10.234.234.234,/10.116.111.18,/192.168.111.18
Wed Nov 11 20:03:21 2020 ERROR [WebServices:web-services-restarter-680] Unable to bind web services listener /10.234.234.234:8773, port may be already in use.
Wed Nov 11 20:03:21 2020 ERROR [WebServices:web-services-restarter-680] Unable to bind web services listener /10.116.111.18:8773, port may be already in use.
Wed Nov 11 20:03:21 2020 ERROR [WebServices:web-services-restarter-680] Unable to bind web services listener /192.168.111.18:8773, port may be already in use.
Wed Nov 11 20:03:21 2020  INFO [WebServices:web-services-restarter-680] Web services restart complete
```

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=620
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/93/
Test: /job/eucalyptus-5-qa-fast/106/

Demo is that the listener is configured / bound as expected:

```
# 
# euctl bootstrap.webservices.listener_address_match
bootstrap.webservices.listener_address_match = 0.0.0.0/32
# 
# 
# netstat -ntlp | grep 8773
tcp        0      0 0.0.0.0:8773            0.0.0.0:*               LISTEN      1518/java   
# 
# 
```

logs:

```
Wed Nov 11 23:13:46 2020  INFO [WebServices:web-services-restarter-696] Starting web services listeners on /0.0.0.0
Wed Nov 11 23:13:46 2020  INFO [WebServices:web-services-restarter-696] Web services restart complete
```

The default value for the underlying property is `0.0.0.0` but `0.0.0.0/32` is equivalent and makes the prefix length explicit.