### PR TITLE
Update eucalyptus-images util for identifier prefix change

### DIFF
--- a/roles/cloud/files/eucalyptus-images
+++ b/roles/cloud/files/eucalyptus-images
@@ -47,4 +47,4 @@ chroot --userspec="nobody" \
   "${TEMP_DIR}/root" \
   "/usr/bin/python2" -c "import os; import sys; os.chdir('/eucalyptus'); sys.path.insert(0,'/eucalyptus'); execfile('images.py')" "$@"
 
-echo -e "To make image public run:\n\n\teuca-modify-image-attribute -l -a all emi-...\n"
+echo -e "To make image public run:\n\n\teuca-modify-image-attribute -l -a all IMAGE_ID\n"


### PR DESCRIPTION
The default prefix for images is now `ami` rather than `emi` so the message output at the end of image upload is updated to be generic.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=634
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/101/
Test: /job/eucalyptus-5-qa-fast/111/

Demo is the updated output:

```
/tmp/bundle-3iziFq/CentOS-7-x86_64-GenericCloud-2003.raw.part.34 100% |===========================|  10.00 MB  17.39 MB/s Time: 0:00:00
/tmp/bundle-3iziFq/CentOS-7-x86_64-GenericCloud-2003.raw.part.35 100% |===========================|   3.14 MB  16.34 MB/s Time: 0:00:00
/tmp/bundle-3iziFq/CentOS-7-x86_64-GenericCloud-2003.raw.manifest.xml 100% |======================|   7.46 kB  75.48 kB/s Time: 0:00:00
IMAGE	ami-b8e10a317ddb1b721

To make image public run:

	euca-modify-image-attribute -l -a all IMAGE_ID
```