### PR TITLE
Node role now sets cluster address as libvirtd listen address

### DIFF
--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -44,6 +44,12 @@
     fi
   when: cloud_instances_conf_cpu_passthrough == "1"
 
+- name: libvirtd listen on cluster address
+  replace:
+    path: /etc/libvirt/libvirtd.conf
+    regexp: '^#?\s*listen_addr\s*=\s*".+"$'
+    replace: 'listen_addr = "{{ eucalyptus_host_cluster_ipv4 }}"'
+
 - name: start libvirtd service
   systemd:
     enabled: true


### PR DESCRIPTION
The libvirtd service must be configured to listen on the cluster address for tls connections as this is internal traffic. 

When the firewall is enabled connections that attempt to use the public address will be blocked which may cause migration failures.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=640
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/103/
Test: /job/eucalyptus-5-qa-fast/113/

Demo is that the listen address is configured on the node controller:

```
# 
# grep listen_addr /etc/libvirt/libvirtd.conf
listen_addr = "10.117.111.16"
# 
# 
```