### PR TITLE
Host interface configuration and lookup

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -27,11 +27,11 @@ cloud_firewalld_configure: no
 
 cloud_firewalld_cluster_cidr: Null
 
-cloud_firewalld_public_interface: "{{ ansible_default_ipv4.interface }}"
+cloud_firewalld_public_interface: "{{ eucalyptus_host_public_interface }}"
 
 cloud_firewalld_public_zone: public
 
-cloud_firewalld_cluster_interface: Null
+cloud_firewalld_cluster_interface: "{{ eucalyptus_host_cluster_interface if eucalyptus_host_public_interface != eucalyptus_host_cluster_interface else None }}"
 
 cloud_firewalld_cluster_zone: internal
 

--- a/roles/ceph-common/tasks/host_facts.yml
+++ b/roles/ceph-common/tasks/host_facts.yml
@@ -3,3 +3,23 @@
   set_fact:
     eucalyptus_host_cluster_ipv4: "{{ host_cluster_ipv4 | default(ansible_default_ipv4.address) }}"
     eucalyptus_host_public_ipv4: "{{ host_public_ipv4 | default(ansible_default_ipv4.address) }}"
+
+- name: set host cluster interface fact
+  set_fact:
+    eucalyptus_host_cluster_interface: "{{ host_cluster_interface }}"
+  when: host_cluster_interface is defined
+
+- name: set host cluster interface by address fact
+  set_fact: "eucalyptus_host_cluster_interface={{ item }}"
+  when: host_cluster_interface is undefined and hostvars[inventory_hostname]['ansible_' + item].ipv4 is defined and hostvars[inventory_hostname]['ansible_' + item].ipv4.address == eucalyptus_host_cluster_ipv4
+  with_items: "{{ ansible_interfaces }}"
+
+- name: set host public interface fact
+  set_fact:
+    eucalyptus_host_public_interface: "{{ host_public_interface }}"
+  when: host_public_interface is defined
+
+- name: set host public interface by address fact
+  set_fact: "eucalyptus_host_public_interface={{ item }}"
+  when: host_public_interface is undefined and hostvars[inventory_hostname]['ansible_' + item].ipv4 is defined and hostvars[inventory_hostname]['ansible_' + item].ipv4.address == eucalyptus_host_public_ipv4
+  with_items: "{{ ansible_interfaces }}"


### PR DESCRIPTION
The public and cluster interfaces for a host can now be configured along with the ip addresses. When the interface is not configured it is now detected by looking up the interface associated with the corresponding ip address.

The firewall interfaces can still be configured with the previous variables in the case that all hosts have the same network interfaces available.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=641
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/104/
Test: /job/eucalyptus-5-qa-fast/114/

Demo is that a deployment with firewall enabled is successful: /job/eucalyptus-internal-5-ado-ansible-deploy/105/