### PR TITLE
Cloud role create accounts during deployment

### DIFF
--- a/roles/cloud/defaults/main.yml
+++ b/roles/cloud/defaults/main.yml
@@ -8,6 +8,9 @@ cloud_properties: {}
 cloud_admin_password: ""
 cloud_service_image_rpm: yes
 cloud_service_image_size: "5"
+cloud_initial_accounts_default: [ "aws", "amazon", "euca" ]
+cloud_initial_accounts_custom: []
+cloud_initial_accounts: "{{ cloud_initial_accounts_default + cloud_initial_accounts_custom }}"
 
 # EDGE network settings
 edge_subnet: "{{ '172.31.0.0' if edge_bridge_create else ansible_default_ipv4.network }}"

--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -336,6 +336,18 @@
     group: root
     mode: 0644
 
+- name: create initial accounts
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euare-accountcreate "{{ item | quote }}"
+  register: shell_result
+  changed_when: '"EntityAlreadyExists" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - '"EntityAlreadyExists" not in shell_result.stderr'
+  with_items: "{{ cloud_initial_accounts | default([]) }}"
+
 - name: admin password/login profile credential
   shell: |
     set -eu


### PR DESCRIPTION
The cloud role now allows accounts to be created during deployment. In the default configuration we create `aws`, `amazon`, and `euca` accounts to reserve these names.

To create additional names the variable `cloud_initial_accounts_custom` can be used. To replace the default names with alternative values the variable `cloud_initial_accounts` should be set.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=644
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/108/
Test: /job/eucalyptus-5-qa-fast/115/