### PR TITLE
Firewalld cluster interface default to Null

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -19,7 +19,7 @@ ceph_facts: "{{ True if (ceph_facts_local or ('ceph' in groups and groups['ceph'
 
 ceph_facts_local: no
 
-ceph_facts_delegate: "{{ 'localhost' if ceph_facts_local else None }}"
+ceph_facts_delegate: "{{ 'localhost' if ceph_facts_local else None|default(omit, True) }}"
 
 ceph_facts_path: /root/eucalyptus/ceph
 
@@ -31,7 +31,7 @@ cloud_firewalld_public_interface: "{{ eucalyptus_host_public_interface }}"
 
 cloud_firewalld_public_zone: public
 
-cloud_firewalld_cluster_interface: "{{ eucalyptus_host_cluster_interface if eucalyptus_host_public_interface != eucalyptus_host_cluster_interface else None }}"
+cloud_firewalld_cluster_interface: "{{ eucalyptus_host_cluster_interface if eucalyptus_host_public_interface != eucalyptus_host_cluster_interface else None|default(omit, True) }}"
 
 cloud_firewalld_cluster_zone: internal
 


### PR DESCRIPTION
Default values for the `ceph-common` role should be `Null` rather than empty string.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=729
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/131/
Test: /job/eucalyptus-5-qa-fast/125/

Demo is that installs are successful for single interface deployments (e.g. faststart)