### PR TITLE
Network configuration options

### DIFF
--- a/roles/cloud/templates/network.yaml.j2
+++ b/roles/cloud/templates/network.yaml.j2
@@ -1,9 +1,15 @@
 Mode: {{ net_mode }}
 
 InstanceDnsServers:
+{% if net_instance_dns_servers %}
+{% for ip in net_instance_dns_servers %}
+- "{{ ip }}"
+{% endfor %}
+{% else %}
 {% for ip in (groups['cloud'] | map('extract', hostvars, ['eucalyptus_host_cluster_ipv4'])) %}
 - "{{ ip }}"
 {% endfor %}
+{% endif %}
 
 PublicIps:
 - "{{ net_public_ip_range }}"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -66,7 +66,11 @@ net_mode_:
 net_private_interface: "{{ net_mode_[net_mode_lower]['private_interface'] }}"
 net_public_interface: en1
 net_bridge_interface: "{{ net_mode_[net_mode_lower]['bridge_interface'] }}"
+net_instance_dns_servers: Null
 net_node_listen_addr: "{{ eucalyptus_host_cluster_ipv4 }}"
+net_node_metadata_ip: Null
+net_node_metadata_use_vm_private: Null
+net_node_proxy: Null
 net_node_router_enabled: "{{ edge_router_enabled }}"
 net_node_router_ip: "{{ edge_router_ip }}"
 

--- a/roles/common/templates/eucalyptus.conf.j2
+++ b/roles/common/templates/eucalyptus.conf.j2
@@ -17,7 +17,16 @@ VNET_MODE="{{ net_mode }}"
 VNET_PRIVINTERFACE="{{ net_private_interface }}"
 VNET_PUBINTERFACE="{{ net_public_interface }}"
 VNET_BRIDGE="{{ net_bridge_interface }}"
+{% if net_node_metadata_use_vm_private %}
+METADATA_USE_VM_PRIVATE="{{ net_node_metadata_use_vm_private }}"
+{% endif %}
+{% if net_node_metadata_ip %}
+METADATA_IP="{{ net_node_metadata_ip }}"
+{% endif %}
 NC_ADDR="{{ net_node_listen_addr }}"
+{% if net_node_proxy %}
+NC_PROXY="{{ net_node_proxy }}"
+{% endif %}
 NC_ROUTER="{{ net_node_router_enabled }}"
 NC_ROUTER_IP="{{ net_node_router_ip }}"
 {{ cloud_instances_conf_custom }}


### PR DESCRIPTION
Network configuration options for instance dns and metadata. This allows `EDGE` networks where services are deployed on a cluster network that is separate from the nodes public and private networks. The instance dns servers and instance metadata ip address can be set to the public ip of the user facing services host.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=730
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/133/
Test: /job/eucalyptus-5-qa-suite/206/

Demo is that tests pass on a qa two host EDGE deployment.