### PR TITLE
Eucalyptus configuration for external database

### DIFF
--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -143,6 +143,10 @@
   command:
     cmd: /usr/sbin/clcadmin-initialize-cloud
     creates: /var/lib/eucalyptus/keys/cloud-cert.pem
+  environment:
+    CLOUD_DB_HOST: "{{ cloud_db_host | default() }}"
+    CLOUD_DB_PORT: "{{ cloud_db_port | default() }}"
+    CLOUD_DB_PASSWORD: "{{ cloud_db_password | default() }}"
 
 - name: start eucalyptus-cloud service
   systemd:

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -31,6 +31,9 @@ cloud_opts_bootstrap_hosts: ""
 cloud_opts_tech_preview: "-Denable.route53.tech.preview=true -Denable.sqs.tech.preview=true"
 cloud_log_level: INFO
 cloud_boostrap_hosts: no
+cloud_db_host: Null
+cloud_db_port: Null
+cloud_db_password: Null
 cloud_instances:
   state_dir: /var/lib/eucalyptus/instances
   conf:

--- a/roles/common/templates/eucalyptus.conf.j2
+++ b/roles/common/templates/eucalyptus.conf.j2
@@ -1,6 +1,11 @@
 # Eucalyptus cloud configuration
 LOGLEVEL="{{ cloud_log_level }}"
 CLOUD_OPTS="{{ cloud_opts }}"
+{% if cloud_db_host %}
+CLOUD_DB_HOST="{{ cloud_db_host }}"
+CLOUD_DB_PORT="{{ cloud_db_port | default() }}"
+CLOUD_DB_PASSWORD="{{ cloud_db_password }}"
+{% endif %}
 NODES="{% for node in groups.node if (inventory_hostname in groups.zone and eucalyptus_zone_name == hostvars[node]['eucalyptus_zone_name']) %}{{ hostvars[node].eucalyptus_host_cluster_ipv4 }} {% endfor %}"
 HYPERVISOR="kvm"
 INSTANCE_PATH="{{ cloud_instances_state_dir }}"


### PR DESCRIPTION
Support for connection to an external database when deploying with specified _cloud_db_host_, _cloud_db_port_, _cloud_db_password_.