### PR TITLE
Ceph hosts epel yum repository and ssh option

### DIFF
--- a/roles/ceph-host/tasks/main.yml
+++ b/roles/ceph-host/tasks/main.yml
@@ -1,3 +1,14 @@
+---
+- name: enable epel yum repository
+  yum:
+    name: epel-release
+    state: latest
+
+- name: install epel gpg key
+  rpm_key:
+    state: present
+    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
+
 # nautilus (14.2.6) ceph-deploy fails unless python-setuptools is present
 - name: install ceph base packages
   yum:
@@ -36,7 +47,7 @@
   authorized_key:
     user: ceph-deploy
     state: present
-    key_options: 'no-port-forwarding,from="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"'
+    key_options: 'no-port-forwarding,from="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,{{ cloud_firewalld_cluster_cidr | default(eucalyptus_host_cluster_ipv4) }}"'
     key: "{{ eucalyptus_ceph_deploy_ssh_public_key }}"
 
 - name: ceph-deploy user ssh public key


### PR DESCRIPTION
Ceph hosts require the epel repository to be available. 

The ssh restrictions for ceph deployment are updated to include the cluster cidr in case there is only a public network in use.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=821
Deploy: https://ocd.appscale.net:8081/job/eucalyptus-internal-5-ado-ansible-deploy/184/
Test: https://ocd.appscale.net:8081/job/eucalyptus-5-qa-fast/142/

Verification is that the ssh option is present:

```
# cat /home/ceph-deploy/.ssh/authorized_keys 
no-port-forwarding,from="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.117.0.0/17" ssh-rsa AAAAB3NzaC...
...
...
```