### PR TITLE
Firewalld reload option

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -38,3 +38,5 @@ cloud_firewalld_cluster_zone: internal
 cloud_firewalld_default_zone: trusted
 
 cloud_firewalld_start: yes
+
+cloud_firewalld_always_reload: no

--- a/roles/ceph-common/tasks/base_firewall.yml
+++ b/roles/ceph-common/tasks/base_firewall.yml
@@ -76,4 +76,4 @@
     state: reloaded
   tags:
     - firewalld
-  when: cloud_firewalld_cluster_cidr is not none and firewalld_result.changed
+  when: (cloud_firewalld_cluster_cidr is not none and firewalld_result.changed) or cloud_firewalld_always_reload

--- a/roles/cloud-post/tasks/main.yml
+++ b/roles/cloud-post/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: firewalld reload
+  systemd:
+    name: firewalld
+    state: reloaded
+  tags:
+    - firewalld
+  when:
+  - cloud_firewalld_configure | default(False)
+  - cloud_firewalld_always_reload | default(False)
+
 - import_tasks: vpcmido.yml
   when: net_mode == "VPCMIDO"
 


### PR DESCRIPTION
Options to always reload the firewall configuration after initial configuration and also before `post` install tasks that may require external access to the cloud (such as https certificate provisioning)

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=821
Deploy: https://ocd.appscale.net:8081/job/eucalyptus-internal-5-ado-ansible-deploy/184/
Test: https://ocd.appscale.net:8081/job/eucalyptus-5-qa-fast/142/