### PR TITLE
Cloud post role certbot script to coordinate certificate upload across all hosts

### DIFF
--- a/roles/cloud-post/files/eucalyptus-certbot-hook
+++ b/roles/cloud-post/files/eucalyptus-certbot-hook
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Import HTTPS key/certificate from PEM files and configure all hosts
+# to use.
+#
+# This hook a/b switches to coordinate moving between certifcates on
+# all hosts and allow manual rollback.
+#
+set -eo pipefail
+
+KEY_ALIAS_A="eucalyptus-cloud-a"
+KEY_ALIAS_B="eucalyptus-cloud-b"
+KEY_ALIAS_PROP="bootstrap.webservices.ssl.server_alias"
+
+KEY_ALIAS_CURRENT=$(euctl -n "${KEY_ALIAS_PROP}")
+KEY_ALIAS_NEXT="${KEY_ALIAS_A}"
+if [ "${KEY_ALIAS_CURRENT}" = "${KEY_ALIAS_A}" ] ; then
+  KEY_ALIAS_NEXT="${KEY_ALIAS_B}"
+fi
+
+TARGET_HOSTS=$(euserv-describe-services \
+  --filter service-type=cluster \
+  --filter service-type=eucalyptus \
+  --filter service-type=storage \
+  --filter service-type=user-api \
+  --group-by-host | awk '{print $2}' | sort -u)
+
+[ -n "${TARGET_HOSTS}" ] || { echo "No hosts found" >&2; exit 3; }
+
+for TARGET_HOST in ${TARGET_HOSTS} ; do
+  export EUCA_PROPERTIES_URL="https://${TARGET_HOST}:8773/services/Properties"
+  "/usr/local/bin/eucalyptus-cloud-https-import" --alias "${KEY_ALIAS_NEXT}" "$@"
+done
+
+unset EUCA_PROPERTIES_URL
+euctl "${KEY_ALIAS_PROP}"="${KEY_ALIAS_NEXT}"

--- a/roles/cloud-post/tasks/certbot.yml
+++ b/roles/cloud-post/tasks/certbot.yml
@@ -27,6 +27,14 @@
     group: root
     mode: 0644
 
+- name: certbot eucalyptus certificate import hook
+  copy:
+    src: eucalyptus-certbot-hook
+    dest: /usr/local/bin/eucalyptus-certbot-hook
+    owner: root
+    group: root
+    mode: 0755
+
 - name: certbot route53 system domain for eucalyptus-cloud authentication
   shell: |
     set -eu
@@ -114,7 +122,7 @@
       --cert-name eucalyptus-cloud \
       --domain "${SERVICE_DOMAINS}" \
       --dns-route53 \
-      --deploy-hook /usr/local/bin/eucalyptus-cloud-https-import \
+      --deploy-hook /usr/local/bin/eucalyptus-certbot-hook \
       ${EXTRA_OPTS}
   args:
     creates: /etc/letsencrypt/live/eucalyptus-cloud/fullchain.pem
@@ -124,9 +132,3 @@
     enabled: true
     state: started
     name: certbot-renew.timer
-
-- name: configure cloud property for services https
-  shell: |
-    set -eu
-    eval $(clcadmin-assume-system-credentials)
-    euctl bootstrap.webservices.ssl.server_alias=eucalyptus-cloud


### PR DESCRIPTION
A script is now added in the cloud post role when using certbot for services. The script handles configuring the certificate alias when updating certificates and uploading of certificates to all hosts.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=825
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/186/
Test: /job/eucalyptus-5-qa-fast/143/