### PR TITLE
Eucalyptus package version configuration

### DIFF
--- a/roles/cloud/defaults/main.yml
+++ b/roles/cloud/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+eucalyptus_package_version: ""
+eucalyptus_package_suffix: "{{ '-' + eucalyptus_package_version if eucalyptus_package_version else '' }}"
+
 # Cloud settings
 cloud_region_region_name: "{{ cloud_region_name }}"
 cloud_listener_cidr: 0.0.0.0/32

--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: install eucalyptus-cloud package
   yum:
-    name: eucalyptus-cloud
+    name: eucalyptus-cloud{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image
@@ -45,7 +45,7 @@
 
 - name: install eucalyptus-walrus package
   yum:
-    name: eucalyptus-walrus
+    name: eucalyptus-walrus{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image
@@ -54,7 +54,7 @@
 
 - name: install eucanetd package
   yum:
-    name: eucanetd
+    name: eucanetd{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -8,6 +8,8 @@ euca2ools_yum_baseurl: http://downloads.eucalyptus.cloud/software/euca2ools/3.4/
 eucalyptus_yum_gpgcheck: "1"
 eucalyptus_base_yum_enabled: no
 eucalyptus_base_yum_baseurl: https://downloads.eucalyptus.cloud/software/eucalyptus/base/5/rhel/7/x86_64/
+eucalyptus_package_version: ""
+eucalyptus_package_suffix: "{{ '-' + eucalyptus_package_version if eucalyptus_package_version else '' }}"
 
 # Product settings
 eucalyptus_product: eucalyptus

--- a/roles/common/tasks/base_config.yml
+++ b/roles/common/tasks/base_config.yml
@@ -9,7 +9,7 @@
 
 - name: install eucalyptus package
   yum:
-    name: eucalyptus
+    name: eucalyptus{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image

--- a/roles/console/defaults/main.yml
+++ b/roles/console/defaults/main.yml
@@ -1,8 +1,13 @@
 ---
+eucalyptus_package_version: ""
+eucalyptus_package_suffix: "{{ '-' + eucalyptus_package_version if eucalyptus_package_version else '' }}"
+
 # Console
 eucaconsole_product: "{{ eucalyptus_product }}"
 eucaconsole_ats_product_url: https://www.appscale.com/product/
 eucaconsole_firewalld_configure: yes
+eucaconsole_package_version: ""
+eucaconsole_package_suffix: "{{ ( '-' + eucaconsole_package_version ) if eucaconsole_package_version else eucalyptus_package_suffix }}"
 
 # Certbot
 eucaconsole_certbot_configure: no

--- a/roles/console/tasks/main.yml
+++ b/roles/console/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: install eucaconsole package
   yum:
     name:
-      - eucaconsole
+      - eucaconsole{{ eucaconsole_package_suffix }}
       - eucaconsole-selinux
     state: present
   tags:

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+eucalyptus_package_version: ""
+eucalyptus_package_suffix: "{{ '-' + eucalyptus_package_version if eucalyptus_package_version else '' }}"
+
 # Network settings
 net_mode: EDGE
 

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: install eucalyptus-node package
   yum:
-    name: eucalyptus-node
+    name: eucalyptus-node{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image
@@ -16,7 +16,7 @@
 - name: install eucanetd package
   when: net_mode == "EDGE"
   yum:
-    name: eucanetd
+    name: eucanetd{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: install eucalyptus-node package
   yum:
-    name: eucalyptus-node{{ eucalyptus_package_suffix }}
+    name: eucalyptus-nc{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image

--- a/roles/zone/defaults/main.yml
+++ b/roles/zone/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+eucalyptus_package_version: ""
+eucalyptus_package_suffix: "{{ '-' + eucalyptus_package_version if eucalyptus_package_version else '' }}"

--- a/roles/zone/tasks/main.yml
+++ b/roles/zone/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: install eucalyptus-cluster package
   yum:
-    name: eucalyptus-cluster
+    name: eucalyptus-cluster{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image
@@ -9,7 +9,7 @@
 
 - name: install eucalyptus-storage package
   yum:
-    name: eucalyptus-storage
+    name: eucalyptus-storage{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image

--- a/roles/zone/tasks/main.yml
+++ b/roles/zone/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: install eucalyptus-cluster package
   yum:
-    name: eucalyptus-cluster{{ eucalyptus_package_suffix }}
+    name: eucalyptus-cc{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image
@@ -9,7 +9,7 @@
 
 - name: install eucalyptus-storage package
   yum:
-    name: eucalyptus-storage{{ eucalyptus_package_suffix }}
+    name: eucalyptus-sc{{ eucalyptus_package_suffix }}
     state: present
   tags:
     - image


### PR DESCRIPTION
The eucalyptus package version can now be specified via a `eucalyptus_package_version` variable.

```
eucalyptus_package_version: "5.0.0"
```

This allows deployment of an older version for expanding existing deployments, testing, etc.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=842
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/197/
Test: /job/eucalyptus-5-qa-fast/149/

Demo is that the deployment fails when set to "5.1.0" with master as that version of the console is not yet present ( /job/eucalyptus-internal-5-ado-ansible-deploy/195/ )