### PR TITLE
Console cloud deployment certbot initialization

### DIFF
--- a/roles/cloud-post/files/console-manage-stack
+++ b/roles/cloud-post/files/console-manage-stack
@@ -76,7 +76,7 @@ fi
 
 if [ "${CMS_ACTION}" = "check" ] ; then
   if ! euform-describe-stacks "console" | grep "^STACK" ; then
-    echo "STACK\tconsole\tNOT_FOUND"
+    echo -e "STACK\tconsole\tNOT_FOUND"
   fi
 elif  [ "${CMS_ACTION}" = "create" ] ; then
   if [ -z "${CONSOLE_EIPALLOCID}" ] || [ -z "${CONSOLE_SUBNETID}" ] || [ -z "${CONSOLE_VPCID}" ] ; then

--- a/roles/cloud/files/console-template.yaml
+++ b/roles/cloud/files/console-template.yaml
@@ -214,7 +214,7 @@ Resources:
               [Unit]
               Description=Eucalyptus Console Certbot Initialization
               After=eucaconsole.service
-              Requires=eucaconsole.service
+              Wants=eucaconsole.service
               AssertPathExists=/etc/eucaconsole/eucaconsole-domain.txt
               
               [Service]


### PR DESCRIPTION
The console instance certbot initialization systemd unit would fail and not restart due to the eucaconsole service initial start failing when configuration files were not present. Using `Wants` for the dependency means the certbot initialization systemd unit will start, and be restarted if there is any failure.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=861
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/205/
Test: /job/eucalyptus-5-qa-fast/156/

Demo is that the output for stack not found is as expected:

```
# console-manage-stack -a check
STACK	console	NOT_FOUND
```

and that the cloudformation template works.
