### PR TITLE
Cloud post role certbot certificate issue updated to include service region endpoints

### DIFF
--- a/roles/cloud-post/tasks/certbot.yml
+++ b/roles/cloud-post/tasks/certbot.yml
@@ -107,6 +107,7 @@
   shell: |
     set -eu
     SERVICE_DOMAINS="{{ eucalyptus_services_endpoints | map('regex_replace', '^(.*)$', '\1.' + cloud_system_dns_dnsdomain) | list | unique | sort | join(',') }}"
+    SERVICE_DOMAINS="${SERVICE_DOMAINS},{{ eucalyptus_services_endpoints | map('regex_replace', '^(.*)$', '\1.' + cloud_region_name + '.' + cloud_system_dns_dnsdomain) | list | unique | sort | join(',') }}"
     REGISTRATION_EMAIL={{ eucalyptus_services_certbot_email | quote }}
     EXTRA_OPTS={{ eucalyptus_services_certbot_certonly_opts | quote }}
     if [ -z "${REGISTRATION_EMAIL}" ] ; then


### PR DESCRIPTION
We expose services via global and regional endpoints, e.g.

```
autoscaling.myats.example.com
autoscaling.cloud-1a.myats.example.com
```

this pull request adds wildcards for services and s3 buckets under the regional namespace, e.g. `*.cloud-1a.myats.example.com`. The regional endpoints are easier to use with some clients that expect the region to be part of the endpoint name.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=889
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/213/
Test: /job/eucalyptus-5-qa-fast/163/