### PR TITLE
Ceph disable snapshot s3 transfer

### DIFF
--- a/roles/zone/tasks/main.yml
+++ b/roles/zone/tasks/main.yml
@@ -109,6 +109,7 @@
     euctl ${ZONE_NAME}.storage.cephsnapshotpools=${CEPH_SNAPSHOT_POOL}
     euctl ${ZONE_NAME}.storage.cephvolumepools=${CEPH_VOLUME_POOL}
     euctl ${ZONE_NAME}.storage.blockstoragemanager=ceph-rbd
+    euctl ${ZONE_NAME}.storage.shouldtransfersnapshots=false
   delegate_to: "{{ groups.cloud[0] }}"
   when: eucalyptus_ceph_conf is defined
 


### PR DESCRIPTION
We use the same ceph deployment for all zones when deploying via ansible. This allows snapshots to be used directly between availability zones without transfer via s3 so this should be disabled for better performance.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=890
Deploy: job/eucalyptus-internal-5-ado-ansible-deploy/214/
Test: /job/eucalyptus-5-qa-fast/164/

Demo is that a snapshot can still be used in any zone:

```
# euca-describe-volumes 
VOLUME	vol-5b1cf4ffebde878fc	1	snap-5969359648f2425a3	cloud-1b	in-use	2021-02-19T04:30:13.199Z	standard	
ATTACHMENT	vol-5b1cf4ffebde878fc	i-33ef14ad0bfce087a	/dev/sdf	attached	2021-02-19T04:31:15.558Z
VOLUME	vol-997253c12657f712d	1		cloud-1a	available	2021-02-19T04:06:42.984Z	standard
#
#
# euca-describe-snapshots
SNAPSHOT	snap-5969359648f2425a3	vol-997253c12657f712d	completed	2021-02-19T04:29:37.055Z	100%	000522212067	1
```