### PR TITLE
eucalyptus-certbot-hook target protocol

### DIFF
--- a/roles/cloud-post/files/eucalyptus-certbot-hook
+++ b/roles/cloud-post/files/eucalyptus-certbot-hook
@@ -29,7 +29,7 @@ TARGET_HOSTS=$(euserv-describe-services \
 [ -n "${TARGET_HOSTS}" ] || { echo "No hosts found" >&2; exit 3; }
 
 for TARGET_HOST in ${TARGET_HOSTS} ; do
-  export EUCA_PROPERTIES_URL="https://${TARGET_HOST}:${TARGET_PORT}/services/Properties"
+  export EUCA_PROPERTIES_URL="http://${TARGET_HOST}:${TARGET_PORT}/services/Properties"
   "/usr/local/bin/eucalyptus-cloud-https-import" --alias "${KEY_ALIAS_NEXT}" "$@"
 done
 


### PR DESCRIPTION
Use http protocol for certbot certificate setup. It is not reliable to use https for certificate setup as the current https settings may be invalid.