### PR TITLE
Network allow multiple ip ranges

### DIFF
--- a/roles/cloud/defaults/main.yml
+++ b/roles/cloud/defaults/main.yml
@@ -21,6 +21,10 @@ edge_netmask: "{{ '255.255.0.0' if edge_bridge_create else ansible_default_ipv4.
 edge_gateway: "{{ '172.31.0.1' if edge_bridge_create else ansible_default_ipv4.gateway }}"
 edge_private_ip_range: "{{ '172.31.0.2-172.31.0.254' if edge_bridge_create else '192.168.254.150-192.168.254.199' }}"
 edge_public_ip_range: 192.168.254.200-192.168.254.249
+edge_private_ip_ranges:
+  - "{{ edge_private_ip_range }}"
+edge_public_ip_ranges:
+  - "{{ edge_public_ip_range }}"
 
 # Firewalld settings
 cloud_firewalld_configure: no
@@ -37,6 +41,10 @@ midonet_midolman_heap: Null
 # VPCMIDO network settings
 vpcmido_public_ip_range: 192.168.254.150-192.168.254.250
 vpcmido_public_ip_cidr: 192.168.254.128/25
+vpcmido_public_ip_ranges:
+  - "{{ vpcmido_public_ip_range }}"
+vpcmido_public_ip_cidrs:
+  - "{{ vpcmido_public_ip_cidr }}"
 vpcmido_gw_ext_cidr: 10.234.234.224/27
 vpcmido_gw_ext_device: euca-mgw-veth1
 vpcmido_gw_ext_ip: 10.234.234.235
@@ -51,10 +59,10 @@ net_mode: EDGE
 net_mode_lower: "{{ net_mode | lower }}"
 net_mode_:
   edge:
-    private_ip_range: "{{ edge_private_ip_range }}"
-    public_ip_range: "{{ edge_public_ip_range }}"
+    private_ip_ranges: "{{ edge_private_ip_ranges }}"
+    public_ip_ranges: "{{ edge_public_ip_ranges }}"
   vpcmido:
-    private_ip_range: Null
-    public_ip_range: "{{ vpcmido_public_ip_range }}"
-net_private_ip_range: "{{ net_mode_[net_mode_lower]['private_ip_range'] }}"
-net_public_ip_range: "{{ net_mode_[net_mode_lower]['public_ip_range'] }}"
+    private_ip_ranges: Null
+    public_ip_ranges: "{{ vpcmido_public_ip_ranges }}"
+net_private_ip_ranges: "{{ net_mode_[net_mode_lower]['private_ip_ranges'] }}"
+net_public_ip_ranges: "{{ net_mode_[net_mode_lower]['public_ip_ranges'] }}"

--- a/roles/cloud/tasks/vpcmido.yml
+++ b/roles/cloud/tasks/vpcmido.yml
@@ -159,10 +159,14 @@
 - name: eucalyptus firewalld midonet gateway service
   template:
     src: firewalld-service-euca-vpcmidogw.xml.j2
-    dest: /etc/firewalld/services/euca-vpcmidogw.xml
+    dest: "/etc/firewalld/services/euca-vpcmidogw-{{ cidr_index }}.xml"
     owner: root
     group: root
     mode: 0644
+  loop: "{{ vpcmido_public_ip_cidrs }}"
+  loop_control:
+    index_var: cidr_index
+    loop_var: cidr
   tags:
     - firewalld
 

--- a/roles/cloud/templates/eucalyptus-vpcmido-gwnet.service.j2
+++ b/roles/cloud/templates/eucalyptus-vpcmido-gwnet.service.j2
@@ -8,7 +8,9 @@ ExecStartPre=-/usr/sbin/ip link add {{ vpcmido_gw_srv_veth0 }} type veth peer na
 ExecStartPre=-/usr/sbin/ip link set dev {{ vpcmido_gw_srv_veth0 }} up
 ExecStartPre=-/usr/sbin/ip link set dev {{ vpcmido_gw_srv_veth1 }} up
 ExecStartPre=-/usr/sbin/ip addr add {{ vpcmido_gw_ext_router_ip }}/{{ vpcmido_gw_srv_veth_prefix }} dev {{ vpcmido_gw_srv_veth0 }}
-ExecStartPre=-/usr/sbin/ip route add {{ vpcmido_public_ip_cidr }} via {{ vpcmido_gw_ext_ip }} dev {{ vpcmido_gw_srv_veth0 }}
+{% for cidr in vpcmido_public_ip_cidrs %}
+ExecStartPre=-/usr/sbin/ip route add {{ cidr }} via {{ vpcmido_gw_ext_ip }} dev {{ vpcmido_gw_srv_veth0 }}
+{% endfor %}
 ExecStart=/usr/bin/true
 
 [Install]

--- a/roles/cloud/templates/firewalld-service-euca-vpcmidogw.xml.j2
+++ b/roles/cloud/templates/firewalld-service-euca-vpcmidogw.xml.j2
@@ -2,5 +2,5 @@
 <service>
   <short>Eucalyptus Cloud Midonet Gateway Service</short>
   <description>Service for Eucalyptus midonet gateway traffic</description>
-  <destination ipv4="{{ vpcmido_public_ip_cidr }}"/>
+  <destination ipv4="{{ cidr }}"/>
 </service>

--- a/roles/cloud/templates/network.yaml.j2
+++ b/roles/cloud/templates/network.yaml.j2
@@ -12,11 +12,15 @@ InstanceDnsServers:
 {% endif %}
 
 PublicIps:
-- "{{ net_public_ip_range }}"
+{% for range in net_public_ip_ranges %}
+- "{{ range }}"
+{% endfor %}
 
 {% if net_mode == 'EDGE' %}
 PrivateIps:
-- "{{ net_private_ip_range }}"
+{% for range in net_private_ip_ranges %}
+- "{{ range }}"
+{% endfor %}
 
 Subnets:
 - Gateway: "{{ edge_gateway }}"


### PR DESCRIPTION
Support for multiple IP range specifications for edge (private, public) and vpc (public) network modes.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=985
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=987