### PR TITLE
CloudFormation dns template update for ttl settings

### DIFF
--- a/roles/cloud/files/eucalyptus-dns-template.yaml
+++ b/roles/cloud/files/eucalyptus-dns-template.yaml
@@ -20,6 +20,21 @@ Parameters:
     Type: String
     Default: ""
 
+  ConsoleTTL:
+    Description: TTL for Eucalyptus Console record
+    Type: String
+    Default: "900"
+
+  NegativeTTL:
+    Description: Negative TTL for the zone SOA record
+    Type: String
+    Default: "5"
+
+  TTL:
+    Description: Default TTL for the zone
+    Type: String
+    Default: "60"
+
 Conditions:
 
   CreateConsoleARecordSet: !Not
@@ -59,12 +74,12 @@ Resources:
         - !Ref "AWS::URLSuffix"
       ResourceRecords:
       - !Sub
-        - "ns1.${SystemDomain}. root.${SystemDomain}. 1 3600 600 86400 3600"
+        - "ns1.${SystemDomain}. root.${SystemDomain}. 1 1200 180 2419200 ${NegativeTTL}"
         - SystemDomain: !If
           - UseSystemDnsDomainParameter
           - !Ref "SystemDnsDomain"
           - !Ref "AWS::URLSuffix"
-      TTL: 60
+      TTL: !Ref TTL
       Type: SOA
 
   ConsoleARecordSet:
@@ -80,7 +95,7 @@ Resources:
           - !Ref "AWS::URLSuffix"
       ResourceRecords:
       - !Ref ConsoleIpAddress
-      TTL: 900
+      TTL: !Ref ConsoleTTL
       Type: A
 
   ConsoleCnameRecordSet:
@@ -96,7 +111,7 @@ Resources:
           - !Ref "AWS::URLSuffix"
       ResourceRecords:
       - !Ref ConsoleCname
-      TTL: 900
+      TTL: !Ref ConsoleTTL
       Type: CNAME
 
 Outputs:


### PR DESCRIPTION
TTL and negative TTL parameters are added and the SOA record values are updated to match functionality in eucalyptus 5.1.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1087
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1088

Demo:

```
#
# euform-create-stack --template-file /var/lib/eucalyptus/templates/eucalyptus-dns-template.yaml dns
arn:aws:cloudformation::000728815355:stack/dns/d8b37633-a20c-44c5-85e8-99cdd54aab13
#
#
# euform-describe-stacks
STACK	dns	CREATE_COMPLETE		Route53 system HostedZone and management console dns for Eucalyptus	2021-04-19T20:19:42.704Z
PARAMETER	SystemDnsDomain		
PARAMETER	ConsoleCname		
PARAMETER	ConsoleIpAddress		
PARAMETER	ConsoleTTL		900
PARAMETER	NegativeTTL		5
PARAMETER	TTL		60
OUTPUT	HostedZoneId	ZAAC57CGJ2TQAP
#
```
