### PR TITLE
Fix use of shell quote filter

### DIFF
--- a/roles/cloud-post/tasks/certbot.yml
+++ b/roles/cloud-post/tasks/certbot.yml
@@ -76,7 +76,9 @@
 - name: wait for certbot firstboot certificate for eucalyptus-cloud
   shell: |
     set -eu
-    HEARTBEAT_URL="https://bootstrap.{{ cloud_system_dns_dnsdomain | quote }}:{{ cloud_public_port | default(8773) }}/services/Heartbeat"
+    HEARTBEAT_DOMAIN={{ cloud_system_dns_dnsdomain | quote }}
+    HEARTBEAT_PORT={{ cloud_public_port | default(8773) | quote }}
+    HEARTBEAT_URL="https://bootstrap.${HEARTBEAT_DOMAIN}:${HEARTBEAT_PORT}/services/Heartbeat"
     wget \
       --ca-certificate /var/lib/eucalyptus/keys/firstboot.pem \
       --quiet \

--- a/roles/cloud-post/tasks/console.yml
+++ b/roles/cloud-post/tasks/console.yml
@@ -14,7 +14,7 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    euare-accountcreate -a "{{ eucalyptus_console_account | quote }}"
+    euare-accountcreate -a {{ eucalyptus_console_account | quote }}
   register: shell_result
   changed_when: '"EntityAlreadyExists" not in shell_result.stderr'
   failed_when:
@@ -26,8 +26,9 @@
     set -euo pipefail
     eval $(clcadmin-assume-system-credentials)
     CONSOLE_IMAGEID=$(euca-describe-images --filter tag:type=eucalyptus-console-image | head -n 1 | grep ^IMAGE | cut -f 2)
-    CONSOLE_ACCOUNT=$(euare-accountlist | grep "^{{ eucalyptus_console_account | quote }}[[:space:]]" | cut -f 2)
-    euca-modify-image-attribute -l -a "${CONSOLE_ACCOUNT}" "${CONSOLE_IMAGEID}"
+    CONSOLE_ACCOUNT_ALIAS={{ eucalyptus_console_account | quote }}
+    CONSOLE_ACCOUNT_NUMBER=$(euare-accountlist | grep "^${CONSOLE_ACCOUNT_ALIAS}[[:space:]]" | cut -f 2)
+    euca-modify-image-attribute -l -a "${CONSOLE_ACCOUNT_NUMBER}" "${CONSOLE_IMAGEID}"
 
 - name: console route53 system domain for eucalyptus-cloud authentication
   shell: |
@@ -45,7 +46,7 @@
 - name: console elastic ip address stack
   shell: |
     set -eu
-    eval $(clcadmin-impersonate-user -a "{{ eucalyptus_console_account | quote }}")
+    eval $(clcadmin-impersonate-user -a {{ eucalyptus_console_account | quote }})
     euform-create-stack --template-file /var/lib/eucalyptus/templates/console-eip-template.yaml console-eip
   register: shell_result
   changed_when: '"AlreadyExists" not in shell_result.stderr'
@@ -56,7 +57,7 @@
 - name: wait for console elastic ip address stack
   shell: |
     set -euo pipefail
-    eval $(clcadmin-impersonate-user -a "{{ eucalyptus_console_account | quote }}")
+    eval $(clcadmin-impersonate-user -a {{ eucalyptus_console_account | quote }})
     euform-describe-stacks console-eip | grep CREATE_COMPLETE
   register: shell_result
   changed_when: False
@@ -66,7 +67,7 @@
 - name: console elastic ip address
   shell: |
     set -euo pipefail
-    eval $(clcadmin-impersonate-user -a "{{ eucalyptus_console_account | quote }}")
+    eval $(clcadmin-impersonate-user -a {{ eucalyptus_console_account | quote }})
     euform-describe-stack-resource -l ElasticIp console-eip | cut -f 3
   register: shell_result
   changed_when: False

--- a/roles/cloud-post/templates/botocore-endpoints.json.j2
+++ b/roles/cloud-post/templates/botocore-endpoints.json.j2
@@ -5,7 +5,7 @@
       "protocols" : [ "https" ],
       "signatureVersions" : [ "v4" ]
     },
-    "dnsSuffix" : "{{ cloud_system_dns_dnsdomain | quote }}:{{ cloud_public_port | default(8773) }}",
+    "dnsSuffix" : "{{ cloud_system_dns_dnsdomain }}:{{ cloud_public_port | default(8773) }}",
     "partition" : "aws",
     "partitionName" : "AWS Standard",
     "regionRegex" : "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",

--- a/roles/cloud-post/templates/console.conf.j2
+++ b/roles/cloud-post/templates/console.conf.j2
@@ -3,12 +3,12 @@
 # See console-manage-stack
 #
 
-CONSOLE_BRANDING="{{ eucalyptus_console_product | quote }}"
+CONSOLE_BRANDING={{ eucalyptus_console_product | quote }}
 CONSOLE_CERTBOT="{{ 'yes' if eucalyptus_console_certbot_enable else 'no' }}"
-CONSOLE_IMAGEID="{{ eucalyptus_console_image_id | quote }}"
-CONSOLE_INSTANCETYPE="{{ eucalyptus_console_instance_type | quote }}"
-CONSOLE_UFSPORT="{{ cloud_public_port | default(8773) }}"
+CONSOLE_IMAGEID={{ eucalyptus_console_image_id | quote }}
+CONSOLE_INSTANCETYPE={{ eucalyptus_console_instance_type | quote }}
+CONSOLE_UFSPORT={{ cloud_public_port | default(8773) }}
 CONSOLE_SERVERCERTID=""
 CONSOLE_SSHKEY=""
-CONSOLE_SSHCIDR="{{ eucalyptus_console_ssh_cidr | quote }}"
-CONSOLE_WEBCIDR="{{ eucalyptus_console_web_cidr | quote }}"
+CONSOLE_SSHCIDR={{ eucalyptus_console_ssh_cidr | quote }}
+CONSOLE_WEBCIDR={{ eucalyptus_console_web_cidr | quote }}

--- a/roles/cloud-post/templates/dnsdist-eucalyptus.conf.j2
+++ b/roles/cloud-post/templates/dnsdist-eucalyptus.conf.j2
@@ -2,7 +2,7 @@
 -- Eucalyptus authoritative DNS server configuration for dnsdist
 --
 
-EUCALYPTUS_DNSDOMAIN = "{{ cloud_system_dns_dnsdomain | quote }}"
+EUCALYPTUS_DNSDOMAIN = "{{ cloud_system_dns_dnsdomain }}"
 
 --
 -- Listener / access control configuration
@@ -17,9 +17,9 @@ setACL({"0.0.0.0/0", "::/0"})
 -- Static DNS responses
 --
 {% if dnsdist_console_ip|default() %}
-addAction("console." .. EUCALYPTUS_DNSDOMAIN, SpoofAction("{{ dnsdist_console_ip | quote }}"))
+addAction("console." .. EUCALYPTUS_DNSDOMAIN, SpoofAction("{{ dnsdist_console_ip }}"))
 {% elif dnsdist_console_cname|default() %}
-addAction("console." .. EUCALYPTUS_DNSDOMAIN, SpoofCNAMEAction("{{ dnsdist_console_cname | quote }}"))
+addAction("console." .. EUCALYPTUS_DNSDOMAIN, SpoofCNAMEAction("{{ dnsdist_console_cname }}"))
 {% else %}
 -- addAction("console.{{ cloud_system_dns_dnsdomain }}", SpoofAction("10.20.30.40"))
 -- addAction("cname-console.{{ cloud_system_dns_dnsdomain }}", SpoofCNAMEAction("console.{{ cloud_system_dns_dnsdomain }}"))

--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -196,10 +196,10 @@
     eval $(clcadmin-assume-system-credentials)
     SERVICES_PORT_OLD="$(euctl -n bootstrap.webservices.port)"
     SERVICES_CIDR_OLD="$(euctl -n bootstrap.webservices.listener_address_match)"
-    SERVICES_PORT_NEW="{{ cloud_listener_port | quote }}"
-    SERVICES_CIDR_NEW="{{ cloud_listener_cidr | quote }}"
-    euctl system.dns.dnsdomain="{{ cloud_system_dns_dnsdomain | quote }}"
-    euctl region.region_name="{{ cloud_region_region_name | quote }}"
+    SERVICES_PORT_NEW={{ cloud_listener_port | quote }}
+    SERVICES_CIDR_NEW={{ cloud_listener_cidr | quote }}
+    euctl system.dns.dnsdomain={{ cloud_system_dns_dnsdomain | quote }}
+    euctl region.region_name={{ cloud_region_region_name | quote }}
     euctl cloud.network.network_configuration=@/etc/eucalyptus/network.yaml
     euctl bootstrap.webservices.use_instance_dns=true
     euctl bootstrap.webservices.use_dns_delegation=true
@@ -226,9 +226,9 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    euctl objectstorage.s3provider.s3endpoint="{{ eucalyptus_minio_endpoint | quote }}"
-    euctl objectstorage.s3provider.s3accesskey="{{ eucalyptus_minio_creds.access_key | quote }}"
-    euctl objectstorage.s3provider.s3secretkey="{{ eucalyptus_minio_creds.secret_key | quote }}"
+    euctl objectstorage.s3provider.s3endpoint={{ eucalyptus_minio_endpoint | quote }}
+    euctl objectstorage.s3provider.s3accesskey={{ eucalyptus_minio_creds.access_key | quote }}
+    euctl objectstorage.s3provider.s3secretkey={{ eucalyptus_minio_creds.secret_key | quote }}
     euctl objectstorage.s3provider.s3endpointheadresponse=400
     euctl objectstorage.providerclient=minio
   when: eucalyptus_ceph_conf is undefined and eucalyptus_minio_endpoint is defined
@@ -240,9 +240,9 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    euctl objectstorage.s3provider.s3endpoint="{{ eucalyptus_ceph_rgw_endpoint | quote }}"
-    euctl objectstorage.s3provider.s3accesskey="{{ eucalyptus_ceph_rgw_creds.access_key | quote }}"
-    euctl objectstorage.s3provider.s3secretkey="{{ eucalyptus_ceph_rgw_creds.secret_key | quote }}"
+    euctl objectstorage.s3provider.s3endpoint={{ eucalyptus_ceph_rgw_endpoint | quote }}
+    euctl objectstorage.s3provider.s3accesskey={{ eucalyptus_ceph_rgw_creds.access_key | quote }}
+    euctl objectstorage.s3provider.s3secretkey={{ eucalyptus_ceph_rgw_creds.secret_key | quote }}
     euctl objectstorage.s3provider.s3endpointheadresponse=200
     euctl objectstorage.providerclient=ceph-rgw
   when: eucalyptus_ceph_conf is defined
@@ -352,7 +352,7 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    euare-accountcreate "{{ item | quote }}"
+    euare-accountcreate {{ item | quote }}
   register: shell_result
   changed_when: '"EntityAlreadyExists" not in shell_result.stderr'
   failed_when:
@@ -364,7 +364,7 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    euare-useraddloginprofile -u admin -p "{{ cloud_admin_password | quote }}"
+    euare-useraddloginprofile -u admin -p {{ cloud_admin_password | quote }}
   register: shell_result
   when: cloud_admin_password|length >= 8
   changed_when: '"EntityAlreadyExists" not in shell_result.stderr'
@@ -377,7 +377,9 @@
     set -eu
     eval $(clcadmin-assume-system-credentials)
     export AWS_DEFAULT_REGION=eucalyptus
-    euare-useraddkey --write-config --domain "{{ cloud_system_dns_dnsdomain | quote }}:{{ cloud_public_port | default(8773) }}" --set-default-user admin > /root/.euca/euca-admin.ini
+    CLOUD_DOMAIN={{ cloud_system_dns_dnsdomain | quote }}
+    CLOUD_PORT={{ cloud_public_port | default(8773) | quote }}
+    euare-useraddkey --write-config --domain "${CLOUD_DOMAIN}:${CLOUD_PORT}" --set-default-user admin > /root/.euca/euca-admin.ini
   args:
     creates: /root/.euca/euca-admin.ini
 
@@ -427,7 +429,7 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    /usr/local/bin/eucalyptus-system-images --type service --size "{{ cloud_service_image_size | quote }}"
+    /usr/local/bin/eucalyptus-system-images --type service --size {{ cloud_service_image_size | quote }}
   register: shell_result
   changed_when: '"image already installed" not in shell_result.stderr'
   failed_when:

--- a/roles/console/tasks/certbot.yml
+++ b/roles/console/tasks/certbot.yml
@@ -16,9 +16,9 @@
 - name: eucaconsole certbot https
   shell: |
     set -eu
-    CONSOLE_DOMAIN="{{ eucaconsole_certbot_domain | quote }}"
-    REGISTRATION_EMAIL="{{ eucaconsole_certbot_email | quote }}"
-    EXTRA_OPTS="{{ eucaconsole_certbot_certonly_opts | quote }}"
+    CONSOLE_DOMAIN={{ eucaconsole_certbot_domain | quote }}
+    REGISTRATION_EMAIL={{ eucaconsole_certbot_email | quote }}
+    EXTRA_OPTS={{ eucaconsole_certbot_certonly_opts | quote }}
     if [ -z "${REGISTRATION_EMAIL}" ] ; then
       EXTRA_OPTS="${EXTRA_OPTS} --register-unsafely-without-email"
     else

--- a/roles/zone/tasks/main.yml
+++ b/roles/zone/tasks/main.yml
@@ -56,7 +56,7 @@
     content: |
       [Service]
       ExecStart=
-      ExecStart=/usr/sbin/tgtd -f --iscsi "portal={{ eucalyptus_host_cluster_ipv4 | quote }}:3260" $TGTD_OPTS
+      ExecStart=/usr/sbin/tgtd -f --iscsi "portal={{ eucalyptus_host_cluster_ipv4 }}:3260" $TGTD_OPTS
   when: eucalyptus_ceph_conf is undefined
 
 - name: start tgtd service
@@ -70,10 +70,10 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    ZONE_NAME="{{ eucalyptus_zone_name | quote }}"
-    ZONE_HOST="{{ eucalyptus_host_cluster_ipv4 | quote }}"
-    euserv-register-service -t cluster -h ${ZONE_HOST} -z ${ZONE_NAME} cluster.${ZONE_HOST}
-    euserv-register-service -t storage -h ${ZONE_HOST} -z ${ZONE_NAME} storage.${ZONE_HOST}
+    ZONE_NAME={{ eucalyptus_zone_name | quote }}
+    ZONE_HOST={{ eucalyptus_host_cluster_ipv4 | quote }}
+    euserv-register-service -t cluster -h "${ZONE_HOST}" -z "${ZONE_NAME}" "cluster.${ZONE_HOST}"
+    euserv-register-service -t storage -h "${ZONE_HOST}" -z "${ZONE_NAME}" "storage.${ZONE_HOST}"
   delegate_to: "{{ groups.cloud[0] }}"
   register: shell_result
   until: shell_result.rc == 0
@@ -83,10 +83,10 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    DAS_DEVICE="{{ cloud_storage_dasdevice | quote }}"
-    ZONE_NAME="{{ eucalyptus_zone_name | quote }}"
-    euctl ${ZONE_NAME}.storage.dasdevice=${DAS_DEVICE}
-    euctl ${ZONE_NAME}.storage.blockstoragemanager=das
+    DAS_DEVICE={{ cloud_storage_dasdevice | quote }}
+    ZONE_NAME={{ eucalyptus_zone_name | quote }}
+    euctl "${ZONE_NAME}.storage.dasdevice"="${DAS_DEVICE}"
+    euctl "${ZONE_NAME}.storage.blockstoragemanager"=das
   delegate_to: "{{ groups.cloud[0] }}"
   when: eucalyptus_ceph_conf is undefined and cloud_storage_dasdevice is defined
 
@@ -94,8 +94,8 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    ZONE_NAME="{{ eucalyptus_zone_name | quote }}"
-    euctl ${ZONE_NAME}.storage.blockstoragemanager=overlay
+    ZONE_NAME={{ eucalyptus_zone_name | quote }}
+    euctl "${ZONE_NAME}.storage.blockstoragemanager"=overlay
   delegate_to: "{{ groups.cloud[0] }}"
   when: eucalyptus_ceph_conf is undefined and cloud_storage_dasdevice is undefined
 
@@ -103,13 +103,13 @@
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    CEPH_SNAPSHOT_POOL="{{ ceph_osd_snapshot_pool | quote }}"
-    CEPH_VOLUME_POOL="{{ ceph_osd_volume_pool | quote }}"
-    ZONE_NAME="{{ eucalyptus_zone_name | quote }}"
-    euctl ${ZONE_NAME}.storage.cephsnapshotpools=${CEPH_SNAPSHOT_POOL}
-    euctl ${ZONE_NAME}.storage.cephvolumepools=${CEPH_VOLUME_POOL}
-    euctl ${ZONE_NAME}.storage.blockstoragemanager=ceph-rbd
-    euctl ${ZONE_NAME}.storage.shouldtransfersnapshots=false
+    CEPH_SNAPSHOT_POOL={{ ceph_osd_snapshot_pool | quote }}
+    CEPH_VOLUME_POOL={{ ceph_osd_volume_pool | quote }}
+    ZONE_NAME={{ eucalyptus_zone_name | quote }}
+    euctl "${ZONE_NAME}.storage.cephsnapshotpools"="${CEPH_SNAPSHOT_POOL}"
+    euctl "${ZONE_NAME}.storage.cephvolumepools"="${CEPH_VOLUME_POOL}"
+    euctl "${ZONE_NAME}.storage.blockstoragemanager"=ceph-rbd
+    euctl "${ZONE_NAME}.storage.shouldtransfersnapshots"=false
   delegate_to: "{{ groups.cloud[0] }}"
   when: eucalyptus_ceph_conf is defined
 


### PR DESCRIPTION
Double quoting was occurring in some cases resulting in deployment failures.

Use of the shell quote filter is removed for usages other than shell.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1105
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1112