### PR TITLE
Network allow multiple ip ranges, firewall

### DIFF
--- a/roles/cloud/tasks/vpcmido.yml
+++ b/roles/cloud/tasks/vpcmido.yml
@@ -198,13 +198,17 @@
     - firewalld
   when: cloud_firewalld_configure and firewalld_result.changed
 
-- name: eucalyptus firewalld midonet gateway service for zone
+- name: eucalyptus firewalld midonet gateway services for zone
   firewalld:
     zone: "{{ cloud_firewalld_vpcmidogw_zone }}"
-    service: euca-vpcmidogw
+    service: "euca-vpcmidogw-{{ cidr_index }}"
     state: enabled
     permanent: yes
     immediate: "{{ cloud_firewalld_start }}"
+  loop: "{{ vpcmido_public_ip_cidrs }}"
+  loop_control:
+    index_var: cidr_index
+    loop_var: cidr
   tags:
     - firewalld
   when: cloud_firewalld_configure and cloud_firewalld_vpcmidogw_zone is not none


### PR DESCRIPTION
Fix related to appscale/ats-deploy#50 to use the service names with an index.

> Support for multiple IP range specifications for edge (private, public) and vpc (public) network modes.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1120
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1121