### PR TITLE
Console role retry https certificate provisioning

### DIFF
--- a/roles/console/tasks/certbot.yml
+++ b/roles/console/tasks/certbot.yml
@@ -40,6 +40,10 @@
       ${EXTRA_OPTS}
   args:
     creates: /etc/letsencrypt/live/eucaconsole/fullchain.pem
+  register: shell_result
+  until: shell_result is succeeded
+  retries: 5
+  delay: 30
 
 - name: eucaconsole certbot https renewal
   systemd:


### PR DESCRIPTION
Add retry for console https certificate provisioning to allow for dns name resolution.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1170
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1185