### PR TITLE
Install and configure container system image for RDS tech preview

### DIFF
--- a/roles/cloud/defaults/main.yml
+++ b/roles/cloud/defaults/main.yml
@@ -11,6 +11,7 @@ cloud_properties: {}
 cloud_admin_password: ""
 cloud_service_image_rpm: yes
 cloud_service_image_size: "5"
+cloud_container_image_size: "2"
 cloud_initial_accounts_default: [ "aws", "amazon", "euca" ]
 cloud_initial_accounts_custom: []
 cloud_initial_accounts: "{{ cloud_initial_accounts_default + cloud_initial_accounts_custom }}"

--- a/roles/cloud/tasks/main.yml
+++ b/roles/cloud/tasks/main.yml
@@ -489,3 +489,32 @@
   register: shell_result
   changed_when: '"not changed" not in shell_result.stderr'
   when: not cloud_service_image_rpm
+
+- name: install container image as system image
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    /usr/local/bin/eucalyptus-system-images --type container --size {{ cloud_container_image_size | quote }}
+  register: shell_result
+  changed_when: '"image already installed" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - shell_result.rc != 2
+  when: (cloud_opts_tech_preview + cloud_opts_custom) is search(cloud_opts_tp_rds | regex_escape())
+
+- name: configure container image cloud properties and launch permissions
+  shell: |
+    set -euo pipefail
+    eval $(clcadmin-assume-system-credentials)
+    CONTAINER_IMAGEID=$(euca-describe-images --filter tag:type=eucalyptus-container-image | head -n 1 | grep ^IMAGE | cut -f 2)
+    OLD_RDS_IMAGEID=$(euctl -n services.rds.worker.image)
+    if [ "${CONTAINER_IMAGEID}" != "${OLD_RDS_IMAGEID}" ] ; then
+      RDS_ACCOUNT_NUMBER=$(euare-accountlist | grep "^(eucalyptus)rds[[:space:]]" | cut -f 2)
+      euca-modify-image-attribute -l -a "${RDS_ACCOUNT_NUMBER}" "${CONTAINER_IMAGEID}"
+      euctl services.rds.worker.image="${CONTAINER_IMAGEID}"
+    else
+      echo "Container image cloud properties not changed." >&2
+    fi
+  register: shell_result
+  changed_when: '"not changed" not in shell_result.stderr'
+  when: (cloud_opts_tech_preview + cloud_opts_custom) is search(cloud_opts_tp_rds |  regex_escape())

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -31,7 +31,11 @@ cloud_opts_custom: ""
 cloud_opts_mem: "-Xmx2g"
 cloud_opts_bindaddr: "--bind-addr={{ eucalyptus_host_cluster_ipv4 }}"
 cloud_opts_bootstrap_hosts: ""
-cloud_opts_tech_preview: "-Denable.route53.tech.preview=true -Denable.sqs.tech.preview=true"
+cloud_opts_tech_preview: "{{ cloud_opts_tp_route53 }} {{ cloud_opts_tp_sqs }}"
+cloud_opts_tp_elbv2: "-Denable.loadbalancingv2.tech.preview=true"
+cloud_opts_tp_route53: "-Denable.route53.tech.preview=true"
+cloud_opts_tp_rds: "-Denable.rds.tech.preview=true"
+cloud_opts_tp_sqs: "-Denable.sqs.tech.preview=true"
 cloud_log_level: INFO
 cloud_boostrap_hosts: no
 cloud_db_host: Null


### PR DESCRIPTION
When the rds service technical preview is enabled install and configure the container system image.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1475
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1476

Demo is that the rds service is available when deployment completes:

```
# euserv-describe-services --filter service-type=rds
SERVICE  rds  api.10.111.10.64  api.10.111.10.64.rds  enabled
```