### PR TITLE
Added options for ceph host public IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Tags can be used to control which aspects of the playbook are used:
 
 * `image` : `packages` and generic configuration
 * `packages` : installs yum repositories and rpms
+* `eucalyptus_get_midonet: downloads only Midonet packages locally
 
 Example tag use:
 
@@ -40,3 +41,18 @@ ansible-playbook --skip-tags image -i inventory.yml playbook.yml
 which would run the playbook in two parts, the first installing packages
 and non-deployment specific configuration, and the second completing the
 deployment.
+
+## Ceph options
+
+The ceph cluster can be configured with its own cluster and public network
+which can and should be separate from the concept of public or cluster
+network for Eucalyptus. The main purpose here is to setup a separate
+storage network to be used by the deploymnet (the ceph_public_network),
+and/or a private ceph network to be used by OSD for synchronization
+(ceph_private_network).
+
+Ceph hosts can be explicitely told which IP is where with ceph_public_ipv4
+and ceph_private_ipv4.
+
+Without any specification the Eucalyputs public and cluster networks will be
+used.

--- a/roles/ceph-common/tasks/ceph_facts.yml
+++ b/roles/ceph-common/tasks/ceph_facts.yml
@@ -32,6 +32,6 @@
 
 - name: set eucalyptus ceph radosgw s3 endpoint fact
   set_fact:
-    eucalyptus_ceph_rgw_endpoint: "{{ hostvars[groups['ceph_object_gateway'][0]]['eucalyptus_host_cluster_ipv4'] }}:7480"
+    eucalyptus_ceph_rgw_endpoint: "{{ hostvars[groups['ceph_object_gateway'][0]]['ceph_public_ipv4'] }}:7480"
   when: eucalyptus_ceph_rgw_host is not defined
 

--- a/roles/ceph-common/tasks/host_facts.yml
+++ b/roles/ceph-common/tasks/host_facts.yml
@@ -4,6 +4,16 @@
     eucalyptus_host_cluster_ipv4: "{{ host_cluster_ipv4 | default(ansible_default_ipv4.address) }}"
     eucalyptus_host_public_ipv4: "{{ host_public_ipv4 | default(ansible_default_ipv4.address) }}"
 
+- name: set host public ceph network
+  set_fact:
+    ceph_public_ipv4: "{{ eucalyptus_host_public_ipv4 }}"
+  when: ceph_public_ipv4 is not defined
+
+- name: set host private ceph network
+  set_fact:
+    ceph_private_ipv4: "{{ eucalyptus_host_cluster_ipv4 }}"
+  when: ceph_public_ipv4 is not defined
+
 - name: set host cluster interface fact
   set_fact:
     eucalyptus_host_cluster_interface: "{{ host_cluster_interface }}"

--- a/roles/ceph-host/tasks/ceph_firewall.yml
+++ b/roles/ceph-host/tasks/ceph_firewall.yml
@@ -8,7 +8,7 @@
     mode: 0644
   tags:
     - firewalld
-  when: ceph_private_network is not none
+  when: cloud_firewalld_configure and ceph_cluster_network is not none
 
 - name: ceph firewalld cluster zone load
   command:
@@ -18,7 +18,7 @@
   register: firewalld_result
   failed_when: "firewalld_result is failed and 'NAME_CONFLICT' not in firewalld_result.stderr"
   changed_when: '"NAME_CONFLICT" not in firewalld_result.stderr'
-  when: ceph_private_network is not none
+  when: cloud_firewalld_configure and ceph_cluster_network is not none
 
 - name: ceph firewalld public zone
   template:
@@ -29,7 +29,11 @@
     mode: 0644
   tags:
     - firewalld
-  when: ceph_public_network is not none
+  when:
+    - cloud_firewalld_configure
+    - ceph_public_network is not none
+    - ceph_cluster_network is not none
+    - ceph_cluster_network != ceph_public_network
 
 - name: ceph firewalld public zone load
   command:
@@ -39,7 +43,11 @@
   register: firewalld_result
   failed_when: "firewalld_result is failed and 'NAME_CONFLICT' not in firewalld_result.stderr"
   changed_when: '"NAME_CONFLICT" not in firewalld_result.stderr'
-  when: ceph_public_network is not none
+  when:
+    - cloud_firewalld_configure
+    - ceph_public_network is not none
+    - ceph_cluster_network is not none
+    - ceph_cluster_network != ceph_public_network
 
 - name: firewalld reload
   systemd:
@@ -47,3 +55,4 @@
     state: reloaded
   tags:
     - firewalld
+  when: cloud_firewalld_configure

--- a/roles/ceph/tasks/ceph_install_deploy.yml
+++ b/roles/ceph/tasks/ceph_install_deploy.yml
@@ -27,7 +27,7 @@
     marker: '# {mark} eucalyptus ceph rgw {{ hostvars[item].ansible_hostname }} configuration'
     block: |
       [client.rgw.{{ hostvars[item].ansible_hostname }}]
-      rgw_frontends = civetweb port={{ hostvars[item].eucalyptus_host_cluster_ipv4 }}:7480
+      rgw_frontends = civetweb port={{ hostvars[item].ceph_public_ipv4 }}:7480
   loop: "{{ groups.ceph_object_gateway }}"
 
 - name: ceph custom configuration for mons
@@ -37,7 +37,7 @@
     block: |
       [mon.{{ hostvars[item].ansible_hostname }}]
       host = {{ hostvars[item].ansible_hostname }}
-      mon addr = {{ hostvars[item].eucalyptus_host_cluster_ipv4 }}:6789
+      mon addr = {{ hostvars[item].ceph_public_ipv4 }}:6789
   loop: "{{ groups.ceph }}"
 
 - name: ceph-deploy install
@@ -70,7 +70,7 @@
     mode: 04750
     recurse: yes
   become: yes
-  become_user: ceph
+  become_user: root
   when: ceph_mgr_create
 
 - name: create osds

--- a/roles/cloud/defaults/main.yml
+++ b/roles/cloud/defaults/main.yml
@@ -54,6 +54,7 @@ vpcmido_gw_srv_veth_create: "{{ vpcmido_gw_ext_device == 'euca-mgw-veth1' }}"
 vpcmido_gw_srv_veth0: euca-mgw-veth0
 vpcmido_gw_srv_veth1: euca-mgw-veth1
 vpcmido_gw_srv_veth_prefix: 27
+vpcmido_dont_log_martians: True
 
 # Network settings
 net_mode: EDGE

--- a/roles/cloud/tasks/vpcmido.yml
+++ b/roles/cloud/tasks/vpcmido.yml
@@ -44,6 +44,19 @@
     cmd: sysctl -w net/ipv4/conf/{{ cloud_firewalld_public_interface }}/proxy_arp=1
   when: vpcmido_gw_srv_veth_create
 
+- name: eucalyptus midonet gateway ip forwarding
+  command:
+    cmd: sysctl -w net/ipv4/conf/{{ cloud_firewalld_public_interface }}/forwarding=1
+  when: vpcmido_gw_srv_veth_create
+
+- name: eucalyptus midonet gateway don't log martians
+  command:
+    cmd: sysctl -w net/ipv4/conf/all/log_martians=0
+  when: vpcmido_gw_srv_veth_create and vpcmido_dont_log_martians
+
+- name: eucalyptus midonet gateway ip forwarding
+  command:
+    cmd: sysctl -w net/ipv4/conf/{{ cloud_firewalld_public_interface }}/forwarding=1
 - name: eucalyptus midonet gateway forwarding / proxy arp persistent
   copy:
     dest: /etc/sysctl.d/80-net-{{ cloud_firewalld_public_interface }}.conf
@@ -53,6 +66,14 @@
       net/ipv4/conf/{{ cloud_firewalld_public_interface }}/forwarding=1
       net/ipv4/conf/{{ cloud_firewalld_public_interface }}/proxy_arp=1
   when: vpcmido_gw_srv_veth_create
+
+- name: eucalyptus midonet gateway don't log martians
+  copy:
+    dest: /etc/sysctl.d/80-net-all.conf
+    mode: 0644
+    content: |
+      net/ipv4/conf/all/log_martians=0
+  when: vpcmido_gw_srv_veth_create and vpcmido_dont_log_martians
 
 - name: midonet defaults configuration
   template:
@@ -172,40 +193,22 @@
   tags:
     - firewalld
 
-- name: eucalyptus firewalld midonet gateway zone
-  template:
-    src: firewalld-zone-euca-vpcmidogw.xml.j2
-    dest: /etc/firewalld/zones/euca-vpcmidogw.xml
-    owner: root
-    group: root
-    mode: 0644
-  tags:
-    - firewalld
-
-- name: eucalyptus firewalld midonet gateway zone load
-  command:
-    cmd: firewall-cmd --permanent --new-zone euca-vpcmidogw
-  tags:
-    - firewalld
-  register: firewalld_result
-  failed_when: "firewalld_result is failed and 'NAME_CONFLICT' not in firewalld_result.stderr"
-  changed_when: '"NAME_CONFLICT" not in firewalld_result.stderr'
-  when: cloud_firewalld_configure
-
-- name: eucalyptus firewalld midonet gateway zone services
+- name: eucalyptus firewalld midonet gateway zone create
   firewalld:
     zone: euca-vpcmidogw
-    service: "euca-vpcmidogw-{{ cidr_index }}"
-    state: enabled
+    state: present
     permanent: yes
-    immediate: "{{ cloud_firewalld_start }}"
-  loop: "{{ vpcmido_public_ip_cidrs }}"
-  loop_control:
-    index_var: cidr_index
-    loop_var: cidr
   tags:
     - firewalld
-  when: cloud_firewalld_configure and cloud_firewalld_vpcmidogw_zone is not none
+  when: cloud_firewalld_configure
+
+- name: firewalld reload
+  systemd:
+    name: firewalld
+    state: reloaded
+  tags:
+    - firewalld
+  when: cloud_firewalld_configure
 
 - name: eucalyptus firewalld midonet gw device to trusted zone
   firewalld:
@@ -216,15 +219,7 @@
     immediate: "{{ cloud_firewalld_start }}"
   tags:
     - firewalld
-  when: cloud_firewalld_configure and vpcmido_gw_ext_device == euca-mgw-veth1
-
-- name: firewalld reload
-  systemd:
-    name: firewalld
-    state: reloaded
-  tags:
-    - firewalld
-  when: cloud_firewalld_configure and firewalld_result.changed
+  when: cloud_firewalld_configure and vpcmido_gw_ext_device == 'euca-mgw-veth1'
 
 - name: eucalyptus firewalld midonet gateway services for zone
   firewalld:
@@ -251,6 +246,21 @@
   tags:
     - firewalld
   when: cloud_firewalld_configure and cloud_firewalld_vpcmidogw_interface is not none
+
+- name: eucalyptus firewalld midonet gateway zone services
+  firewalld:
+    zone: euca-vpcmidogw
+    service: "euca-vpcmidogw-{{ cidr_index }}"
+    state: enabled
+    permanent: yes
+    immediate: "{{ cloud_firewalld_start }}"
+  loop: "{{ vpcmido_public_ip_cidrs }}"
+  loop_control:
+    index_var: cidr_index
+    loop_var: cidr
+  tags:
+    - firewalld
+  when: cloud_firewalld_configure and cloud_firewalld_vpcmidogw_zone is not none
 
 - name: eucalyptus tunnel zone midonet configuration
   template:

--- a/roles/cloud/templates/firewalld-zone-euca-vpcmidogw.xml.j2
+++ b/roles/cloud/templates/firewalld-zone-euca-vpcmidogw.xml.j2
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<zone>
-  <short>Eucalyptus Cloud Midonet Gateway Zone</short>
-  <description>Zone for Eucalyptus midonet gateway traffic</description>
-</zone>

--- a/roles/none/tasks/main.yml
+++ b/roles/none/tasks/main.yml
@@ -345,8 +345,8 @@
   find:
     paths: /etc/sysctl.d/
     file_type: file
-    patterns: '80-net-*.conf'
-    use_regex: true
+    patterns: '^80-net-.*.conf'
+    use_regex: yes
   register: netfiles
 
 - name: remove the sysctl added rules
@@ -375,12 +375,6 @@
   - "/etc/firewalld/services/euca-vpcmidogw-4.xml"
   - "/etc/firewalld/services/euca-vpcmidogw-5.xml"
 
-- name: firewalld reload
-  systemd:
-    name: firewalld
-    state: reloaded
-  when: cloud_firewalld_configure | default(False)
-
 - name: remove midonet gw interface from firewalld zone
   firewalld:
     zone: trusted
@@ -390,6 +384,12 @@
     immediate: yes
   tags:
     - firewalld
+  when: cloud_firewalld_configure | default(False)
+
+- name: firewalld reload
+  systemd:
+    name: firewalld
+    state: reloaded
   when: cloud_firewalld_configure | default(False)
 
 - name: remove minio application directory


### PR DESCRIPTION
Added ceph_public_ipv4 and ceph_private_ipv4 to make explicit use of
separated storage networks when available. In this case the public
networl will be used for node <-> ceph communication as as well radosgw
communication.

Also added some VPCMIDONET improvement, like don't log martian by
default, made explicit the need for IP forwarding when using veth.