### PR TITLE
Change ufsport in console.ini to what is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,35 @@ cp inventory_example.yml inventory.yml
 vi inventoy.yml
 ```
 
-to install with EDGE network mode:
+## Configuration
+
+The important options to set up are:
+
+```
+cloud_system_dns_dnsdomain=<DNS subdomain this deployment is responsible for>
+vpcmido_public_ip_cidr=<public IPs available to the instances>
+```
+
+the DNS subdomain needs to be delegated to the cloud (CLC) machine. For
+example to delegate ats.mydomain.foo with dnsmasq you cam add:
+
+```
+server=/ats.mydomain.foo/<CLC IP address>
+```
+
+to enable the delegation.
+
+
+
+## Installing the different networks mode
+
+To install with EDGE network mode:
 
 ```
 ansible-playbook -i inventory.yml playbook[_edge].yml
 ```
 
-to install with VPCMIDO network mode:
+to install with VPCMIDO network mode (recommended):
 
 ```
 ansible-playbook -i inventory.yml playbook_vpcmido.yml
@@ -34,8 +56,9 @@ Tags can be used to control which aspects of the playbook are used:
 Example tag use:
 
 ```
-ansible-playbook --tags      image -i inventory.yml playbook.yml
-ansible-playbook --skip-tags image -i inventory.yml playbook.yml
+ansible-playbook --tags      image             -i inventory.yml playbook.yml
+ansible-playbook --skip-tags image             -i inventory.yml playbook.yml
+ansible-playbook --skip-tags selinux,firewalld -i inventory.yml playbook.yml
 ```
 
 which would run the playbook in two parts, the first installing packages

--- a/roles/ceph-common/tasks/base_packages.yml
+++ b/roles/ceph-common/tasks/base_packages.yml
@@ -5,6 +5,7 @@
       - net-tools
       - rsync
       - wget
+      - iproute
     state: present
   tags:
     - image

--- a/roles/common/tasks/download_midonet.yml
+++ b/roles/common/tasks/download_midonet.yml
@@ -9,6 +9,7 @@
   when: eucalyptus_get_midonet
   tags:
   - midonet-packages
+  - packages
 
 - name: downloads midonet RPMs
   get_url:
@@ -24,6 +25,7 @@
   when: eucalyptus_get_midonet
   tags:
   - midonet-packages
+  - packages
 
 - name: downloads midonet-misc (noarch) RPMs
   get_url:
@@ -37,6 +39,7 @@
   when: eucalyptus_get_midonet
   tags:
   - midonet-packages
+  - packages
 
 - name: downloads midonet-misc (x86_64) RPMs
   get_url:
@@ -59,5 +62,6 @@
   when: eucalyptus_get_midonet
   tags:
   - midonet-packages
+  - packages
 
 

--- a/roles/console/tasks/main.yml
+++ b/roles/console/tasks/main.yml
@@ -26,6 +26,12 @@
     regexp: '^ufshost = .+$'
     replace: 'ufshost = {{ cloud_system_dns_dnsdomain }}'
 
+- name: eucaconsole ufsport configuration
+  replace:
+    path: /etc/eucaconsole/console.ini
+    regexp: '^ufsport = .+$'
+    replace: 'ufsport = {{ cloud_public_port }}'
+
 - name: eucaconsole aws login configuration
   replace:
     path: /etc/eucaconsole/console.ini


### PR DESCRIPTION
This allowed to set the console.ini to talk to the CLC on the proper
port (the one configured in case it's not the default).