### PR TITLE
Fixed silencing the martians in the log

### DIFF
--- a/roles/cloud/tasks/vpcmido.yml
+++ b/roles/cloud/tasks/vpcmido.yml
@@ -41,38 +41,34 @@
 
 - name: eucalyptus midonet gateway proxy arp runtime
   command:
-    cmd: sysctl -w net/ipv4/conf/{{ cloud_firewalld_public_interface }}/proxy_arp=1
+    cmd: sysctl -w net.ipv4.conf.{{ cloud_firewalld_public_interface }}.proxy_arp=1
+  when: vpcmido_gw_srv_veth_create
+
+- name: eucalyptus midonet gateway ip forwarding
+  command:
+    cmd: sysctl -w net.ipv4.conf.{{ cloud_firewalld_public_interface }}.forwarding=1
   when: vpcmido_gw_srv_veth_create
 
 - name: eucalyptus midonet gateway ip forwarding
   command:
     cmd: sysctl -w net/ipv4/conf/{{ cloud_firewalld_public_interface }}/forwarding=1
-  when: vpcmido_gw_srv_veth_create
 
-- name: eucalyptus midonet gateway don't log martians
-  command:
-    cmd: sysctl -w net/ipv4/conf/all/log_martians=0
-  when: vpcmido_gw_srv_veth_create and vpcmido_dont_log_martians
-
-- name: eucalyptus midonet gateway ip forwarding
-  command:
-    cmd: sysctl -w net/ipv4/conf/{{ cloud_firewalld_public_interface }}/forwarding=1
 - name: eucalyptus midonet gateway forwarding / proxy arp persistent
   copy:
     dest: /etc/sysctl.d/80-net-{{ cloud_firewalld_public_interface }}.conf
     mode: 0644
     content: |
       # Enable forwarding and proxy arp for eucalyptus midonet gateway
-      net/ipv4/conf/{{ cloud_firewalld_public_interface }}/forwarding=1
-      net/ipv4/conf/{{ cloud_firewalld_public_interface }}/proxy_arp=1
+      net.ipv4.conf.{{ cloud_firewalld_public_interface }}.forwarding = 1
+      net.ipv4.conf.{{ cloud_firewalld_public_interface }}.proxy_arp = 1
   when: vpcmido_gw_srv_veth_create
 
 - name: eucalyptus midonet gateway don't log martians
   copy:
-    dest: /etc/sysctl.d/80-net-all.conf
+    dest: /etc/sysctl.d/80-net-{{ vpcmido_gw_srv_veth0 }}.conf
     mode: 0644
     content: |
-      net/ipv4/conf/all/log_martians=0
+      net.ipv4.conf.{{ vpcmido_gw_srv_veth0 }}.log_martians = 0
   when: vpcmido_gw_srv_veth_create and vpcmido_dont_log_martians
 
 - name: midonet defaults configuration

--- a/roles/cloud/templates/eucalyptus-vpcmido-gwnet.service.j2
+++ b/roles/cloud/templates/eucalyptus-vpcmido-gwnet.service.j2
@@ -12,6 +12,9 @@ ExecStartPre=-/usr/sbin/ip addr add {{ vpcmido_gw_ext_router_ip }}/{{ vpcmido_gw
 ExecStartPre=-/usr/sbin/ip route add {{ cidr }} via {{ vpcmido_gw_ext_ip }} dev {{ vpcmido_gw_srv_veth0 }}
 {% endfor %}
 ExecStart=/usr/bin/true
+{% if vpcmido_dont_log_martians %}
+ExecStartPre=-/usr/sbin/sysctl -w net.ipv4.conf.{{ vpcmido_gw_srv_veth0 }}.log_martians=0
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We used the wrong separator, and make sure we silence them only if the
configuration tells us to.