### PR TITLE
Fix creation of firewall zones

### DIFF
--- a/roles/ceph-common/tasks/base_firewall.yml
+++ b/roles/ceph-common/tasks/base_firewall.yml
@@ -5,7 +5,7 @@
     name: firewalld
   tags:
     - firewalld
-  when: cloud_firewalld_start
+  when: cloud_firewalld_configure
 
 - name: firewalld public interface zone
   firewalld:
@@ -29,6 +29,16 @@
     - firewalld
   when: cloud_firewalld_cluster_interface is not none and cloud_firewalld_cluster_zone is not none
 
+- name: eucalyptus firewalld cluster zone load
+  command:
+    cmd: firewall-cmd --permanent --new-zone euca-cluster
+  tags:
+    - firewalld
+  register: firewalld_result
+  failed_when: "firewalld_result is failed and 'NAME_CONFLICT' not in firewalld_result.stderr"
+  changed_when: '"NAME_CONFLICT" not in firewalld_result.stderr'
+  when: cloud_firewalld_cluster_cidr is not none
+
 - name: eucalyptus gre service
   copy:
     src: firewalld-service-euca-gre.xml
@@ -36,6 +46,7 @@
     owner: root
     group: root
     mode: 0644
+    force: yes
   tags:
     - firewalld
   when: cloud_firewalld_cluster_cidr is not none
@@ -47,18 +58,9 @@
     owner: root
     group: root
     mode: 0644
+    force: yes
   tags:
     - firewalld
-  when: cloud_firewalld_cluster_cidr is not none
-
-- name: eucalyptus firewalld cluster zone load
-  command:
-    cmd: firewall-cmd --permanent --new-zone euca-cluster
-  tags:
-    - firewalld
-  register: firewalld_result
-  failed_when: "firewalld_result is failed and 'NAME_CONFLICT' not in firewalld_result.stderr"
-  changed_when: '"NAME_CONFLICT" not in firewalld_result.stderr'
   when: cloud_firewalld_cluster_cidr is not none
 
 - name: firewalld default zone

--- a/roles/ceph-host/tasks/ceph_firewall.yml
+++ b/roles/ceph-host/tasks/ceph_firewall.yml
@@ -1,15 +1,4 @@
 ---
-- name: ceph firewalld cluster zone
-  template:
-    src: firewalld-zone-ceph-cluster.xml.j2 
-    dest: /etc/firewalld/zones/ceph-cluster.xml
-    owner: root
-    group: root
-    mode: 0644
-  tags:
-    - firewalld
-  when: cloud_firewalld_configure and ceph_cluster_network is not none
-
 - name: ceph firewalld cluster zone load
   command:
     cmd: firewall-cmd --permanent --new-zone ceph-cluster
@@ -18,22 +7,25 @@
   register: firewalld_result
   failed_when: "firewalld_result is failed and 'NAME_CONFLICT' not in firewalld_result.stderr"
   changed_when: '"NAME_CONFLICT" not in firewalld_result.stderr'
-  when: cloud_firewalld_configure and ceph_cluster_network is not none
+  when:
+    - cloud_firewalld_configure
+    - ceph_cluster_network is not none
+    - ceph_cluster_network != cloud_firewalld_cluster_cidr
 
-- name: ceph firewalld public zone
+- name: ceph firewalld cluster zone
   template:
-    src: firewalld-zone-ceph-public.xml.j2
-    dest: /etc/firewalld/zones/ceph-public.xml
+    src: firewalld-zone-ceph-cluster.xml.j2
+    dest: /etc/firewalld/zones/ceph-cluster.xml
     owner: root
     group: root
+    force: yes
     mode: 0644
   tags:
     - firewalld
   when:
     - cloud_firewalld_configure
-    - ceph_public_network is not none
     - ceph_cluster_network is not none
-    - ceph_cluster_network != ceph_public_network
+    - ceph_cluster_network != cloud_firewalld_cluster_cidr
 
 - name: ceph firewalld public zone load
   command:
@@ -46,8 +38,20 @@
   when:
     - cloud_firewalld_configure
     - ceph_public_network is not none
-    - ceph_cluster_network is not none
-    - ceph_cluster_network != ceph_public_network
+
+- name: ceph firewalld public zone
+  template:
+    src: firewalld-zone-ceph-public.xml.j2
+    dest: /etc/firewalld/zones/ceph-public.xml
+    owner: root
+    group: root
+    force: yes
+    mode: 0644
+  tags:
+    - firewalld
+  when:
+    - cloud_firewalld_configure
+    - ceph_public_network is not none
 
 - name: firewalld reload
   systemd:


### PR DESCRIPTION
The creation of the empty firewall zone needs to be done before copying
the template.