### PR TITLE
Allow for console route53 entry to be modified

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -52,16 +52,16 @@
   roles:
   - node
 
+- hosts: cloud
+  roles:
+  - cloud-post
+
 - hosts: console
   module_defaults:
     yum:
       disablerepo: "{{ eucalyptus_yum_disablerepo | default(omit) }}"
   roles:
   - console
-
-- hosts: cloud
-  roles:
-  - cloud-post
 
 - hosts: all
   roles:

--- a/roles/cloud-post/tasks/certbot.yml
+++ b/roles/cloud-post/tasks/certbot.yml
@@ -11,6 +11,12 @@
   tags:
     - packages
 
+- name: fix issues with latest CentOS 7
+  yum:
+    name: python-s3transfer.0.1.13-1.el7.0.1
+    allow_downgrade: yes
+    state: present
+
 - name: certbot-renew service.d directory
   file:
     path: /etc/systemd/system/certbot-renew.service.d
@@ -26,19 +32,6 @@
     owner: root
     group: root
     mode: 0644
-
-- name: certbot route53 system domain for eucalyptus-cloud authentication
-  shell: |
-    set -eu
-    eval $(clcadmin-assume-system-credentials)
-    euform-create-stack \
-      --template-file /var/lib/eucalyptus/templates/eucalyptus-dns-template.yaml \
-      eucalyptus-dns
-  register: shell_result
-  changed_when: '"AlreadyExists" not in shell_result.stderr'
-  failed_when:
-    - shell_result.rc != 0
-    - '"AlreadyExists" not in shell_result.stderr'
 
 - name: certbot firstboot certificate for eucalyptus-cloud
   shell: |

--- a/roles/cloud-post/tasks/console.yml
+++ b/roles/cloud-post/tasks/console.yml
@@ -30,19 +30,6 @@
     CONSOLE_ACCOUNT_NUMBER=$(euare-accountlist | grep "^${CONSOLE_ACCOUNT_ALIAS}[[:space:]]" | cut -f 2)
     euca-modify-image-attribute -l -a "${CONSOLE_ACCOUNT_NUMBER}" "${CONSOLE_IMAGEID}"
 
-- name: console route53 system domain for eucalyptus-cloud authentication
-  shell: |
-    set -eu
-    eval $(clcadmin-assume-system-credentials)
-    euform-create-stack \
-      --template-file /var/lib/eucalyptus/templates/eucalyptus-dns-template.yaml \
-      eucalyptus-dns
-  register: shell_result
-  changed_when: '"AlreadyExists" not in shell_result.stderr'
-  failed_when:
-    - shell_result.rc != 0
-    - '"AlreadyExists" not in shell_result.stderr'
-
 - name: console elastic ip address stack
   shell: |
     set -eu

--- a/roles/cloud-post/tasks/main.yml
+++ b/roles/cloud-post/tasks/main.yml
@@ -12,6 +12,19 @@
 - import_tasks: vpcmido.yml
   when: net_mode == "VPCMIDO"
 
+- name: route53 system domain setup
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euform-create-stack \
+      --template-file /var/lib/eucalyptus/templates/eucalyptus-dns-template.yaml \
+      eucalyptus-dns
+  register: shell_result
+  changed_when: '"AlreadyExists" not in shell_result.stderr'
+  failed_when:
+    - shell_result.rc != 0
+    - '"AlreadyExists" not in shell_result.stderr'
+
 - import_tasks: console.yml
   when: eucalyptus_console_cloud_deploy and net_mode == "VPCMIDO"
 

--- a/roles/console/defaults/main.yml
+++ b/roles/console/defaults/main.yml
@@ -8,6 +8,7 @@ eucaconsole_ats_product_url: https://www.appscale.com/product/
 eucaconsole_firewalld_configure: yes
 eucaconsole_package_version: ""
 eucaconsole_package_suffix: "{{ ( '-' + eucaconsole_package_version ) if eucaconsole_package_version else eucalyptus_package_suffix }}"
+eucalyptus_console_cname: "ec2.{{ cloud_system_dns_dnsdomain | default('localhost') }}"
 
 # Certbot
 eucaconsole_certbot_configure: no

--- a/roles/console/tasks/certbot.yml
+++ b/roles/console/tasks/certbot.yml
@@ -8,6 +8,12 @@
   tags:
     - packages
 
+- name: fix issues with latest CentOS 7
+  yum:
+    name: python-s3transfer.0.1.13-1.el7.0.1
+    allow_downgrade: yes
+    state: present
+
 - name: certbot configuration to issue for service endpoints
   set_fact:
     eucaconsole_certbot_domain: "{{ eucaconsole_certbot_domain }},{{ eucaconsole_certbot_services | map('regex_replace', '^(.*)$', '\\1.' + cloud_system_dns_dnsdomain) | list | unique | sort | join(',') }}"

--- a/roles/console/tasks/main.yml
+++ b/roles/console/tasks/main.yml
@@ -67,11 +67,11 @@
   - http
   - https
 
-- name: certbot system domain for eucalyptus-cloud
+- name: update console route53 entry for eucalyptus-cloud
   shell: |
     set -eu
     eval $(clcadmin-assume-system-credentials)
-    euform-create-stack \
+    euform-update-stack \
       --template-file /var/lib/eucalyptus/templates/eucalyptus-dns-template.yaml \
       -p ConsoleCname={{ eucalyptus_console_cname | default | quote }} \
       -p ConsoleIpAddress={{ eucalyptus_console_ipv4 | default | quote }} \
@@ -79,16 +79,17 @@
   delegate_to: "{{ groups.cloud[0] }}"
   when: eucalyptus_console_cname is defined or eucalyptus_console_ipv4 is defined
   register: shell_result
-  changed_when: '"AlreadyExists" not in shell_result.stderr'
+  changed_when: '"No updates are to be performed" not in shell_result.stderr'
   failed_when:
     - shell_result.rc != 0
-    - '"AlreadyExists" not in shell_result.stderr'
+    - '"No updates are to be performed" not in shell_result.stderr'
+
 
 - name: wait for certbot system domain for eucalyptus-cloud stack
   shell: |
     set -euo pipefail
     eval $(clcadmin-assume-system-credentials)
-    euform-describe-stacks eucalyptus-dns | grep CREATE_COMPLETE
+    euform-describe-stacks eucalyptus-dns | grep UPDATE_COMPLETE
   delegate_to: "{{ groups.cloud[0] }}"
   when: (eucalyptus_console_cname is defined or eucalyptus_console_ipv4 is defined) and shell_result.changed
   register: shell_result


### PR DESCRIPTION
These changes allow for the console route53 entry to be modified. By default a CNAME default entry to ec2. has been added, assuming that the console has been started on the CLC machine.