### PR TITLE
Don't use variable not defined

### DIFF
--- a/roles/cloud-post/tasks/main.yml
+++ b/roles/cloud-post/tasks/main.yml
@@ -123,10 +123,3 @@
     - shell_result.rc != 0
     - '"No updates are to be performed" not in shell_result.stderr'
 
-- name: restart dnsmasq service
-  systemd:
-    enabled: true
-    state: restarted
-    name: dnsmasq
-  when: cloud_use_dnsmasq
-  


### PR DESCRIPTION
We cannot restart here dnsmasq using a variable which is not defined in this role. For now, if some resposne are not right after re-running the playbook (while changing route53) we may need to wait the reload dnsmasq by hand.