### PR TITLE
Adjust some ceph options

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,9 @@ and ceph_private_ipv4.
 
 Without any specification the Eucalyputs public and cluster networks will be
 used.
+
+```
+ceph_osd_pool_pgnum: 256
+```
+This value should be adjusted to the specific ceph deployments (number of
+OSDs, nodes, expected use etc...).

--- a/inventory_example_local.yml
+++ b/inventory_example_local.yml
@@ -29,6 +29,7 @@ all:
     midonet_zookeeper_heap: 512m
     midonet_cluster_heap: 512m
     midonet_midolman_heap: 512m
+    ceph_osd_pool_pgnum: 16
     
     # If using EDGE then br0 must be configured and these
     # ip address ranges should be updated

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -12,7 +12,7 @@ ceph_osd_volume_pool: eucavolumes
 
 ceph_osd_snapshot_pool: eucasnapshots
 
-ceph_osd_pool_pgnum: 16
+ceph_osd_pool_pgnum: 256
 
 ceph_rgw_uid: eucas3
 

--- a/roles/ceph/files/ceph-euca-setup.sh
+++ b/roles/ceph/files/ceph-euca-setup.sh
@@ -14,6 +14,8 @@ if ! ceph osd pool ls | grep -q ${EUCA_CEPH_VOLUME_POOL_NAME} ; then
     echo "Generating volume pool ${EUCA_CEPH_VOLUME_POOL_NAME}"
     ceph osd pool create ${EUCA_CEPH_VOLUME_POOL_NAME} ${EUCA_POOL_PLACEMENT_GROUPS}
     ceph osd pool application enable ${EUCA_CEPH_VOLUME_POOL_NAME} rbd 2>/dev/null || true
+    ceph balancer mode upmap
+    ceph balancer on
 fi
 
 if [ "${EUCA_CEPH_VOLUME_POOL_NAME}" != "${EUCA_CEPH_SNAPSHOT_POOL_NAME}" ] ; then


### PR DESCRIPTION
Make sure we have the balancer set up, as well as raise the basic number of pg and added the ceph_osd_pool_pgnum to the README to explicitly encourage to configure it on a per deployment basis.