### PR TITLE
Fix release to nautilus

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-ceph_release: jewel
+ceph_release: nautilus
 
 ceph_public_network: 192.168.0.0/16
 

--- a/roles/ceph/files/ceph-euca-setup.sh
+++ b/roles/ceph/files/ceph-euca-setup.sh
@@ -14,8 +14,6 @@ if ! ceph osd pool ls | grep -q ${EUCA_CEPH_VOLUME_POOL_NAME} ; then
     echo "Generating volume pool ${EUCA_CEPH_VOLUME_POOL_NAME}"
     ceph osd pool create ${EUCA_CEPH_VOLUME_POOL_NAME} ${EUCA_POOL_PLACEMENT_GROUPS}
     ceph osd pool application enable ${EUCA_CEPH_VOLUME_POOL_NAME} rbd 2>/dev/null || true
-    ceph balancer mode upmap
-    ceph balancer on
 fi
 
 if [ "${EUCA_CEPH_VOLUME_POOL_NAME}" != "${EUCA_CEPH_SNAPSHOT_POOL_NAME}" ] ; then
@@ -28,6 +26,10 @@ fi
 
 if [ -n "${EUCA_CEPH_MIN_CLIENT}" ] ; then
     ceph osd set-require-min-compat-client "${EUCA_CEPH_MIN_CLIENT}"
+    if [[ "${EUCA_CEPH_MIN_CLIENT:0:1}" > "l" ]]; then
+        ceph balancer mode upmap
+        ceph balancer on
+    fi
 fi
 
 if [ ! -e "${EUCA_CEPH_ARTIFACTS_DIR}" ] ; then

--- a/roles/console/tasks/certbot.yml
+++ b/roles/console/tasks/certbot.yml
@@ -3,7 +3,10 @@
 
 - name: install certbot package
   yum:
-    name: certbot
+    name:
+    - certbot
+    - python2-certbot-dns-route53
+    - python2-futures
     state: present
   tags:
     - packages


### PR DESCRIPTION
Fixing the release allow to set a minum client, thus to allow the balancer to start by default and remove the ceph warning.