### PR TITLE
Enable pg_autoscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,3 @@ and ceph_private_ipv4.
 Without any specification the Eucalyputs public and cluster networks will be
 used.
 
-```
-ceph_osd_pool_pgnum: 256
-```
-This value should be adjusted to the specific ceph deployments (number of
-OSDs, nodes, expected use etc...).

--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -12,7 +12,7 @@ ceph_osd_volume_pool: eucavolumes
 
 ceph_osd_snapshot_pool: eucasnapshots
 
-ceph_osd_pool_pgnum: 256
+ceph_osd_pool_pgnum: 16
 
 ceph_rgw_uid: eucas3
 

--- a/roles/ceph/files/ceph-euca-setup.sh
+++ b/roles/ceph/files/ceph-euca-setup.sh
@@ -14,6 +14,10 @@ if ! ceph osd pool ls | grep -q ${EUCA_CEPH_VOLUME_POOL_NAME} ; then
     echo "Generating volume pool ${EUCA_CEPH_VOLUME_POOL_NAME}"
     ceph osd pool create ${EUCA_CEPH_VOLUME_POOL_NAME} ${EUCA_POOL_PLACEMENT_GROUPS}
     ceph osd pool application enable ${EUCA_CEPH_VOLUME_POOL_NAME} rbd 2>/dev/null || true
+    if [[ "${EUCA_CEPH_MIN_CLIENT:0:1}" > "l" ]]; then
+        ceph mgr module enable pg_autoscaler
+        ceph osd pool set ${EUCA_CEPH_VOLUME_POOL_NAME} pg_autoscale_mode on
+    fi
 fi
 
 if [ "${EUCA_CEPH_VOLUME_POOL_NAME}" != "${EUCA_CEPH_SNAPSHOT_POOL_NAME}" ] ; then
@@ -21,6 +25,10 @@ if [ "${EUCA_CEPH_VOLUME_POOL_NAME}" != "${EUCA_CEPH_SNAPSHOT_POOL_NAME}" ] ; th
         echo "Generating snapshot pool ${EUCA_CEPH_SNAPSHOT_POOL_NAME}"
         ceph osd pool create ${EUCA_CEPH_SNAPSHOT_POOL_NAME} ${EUCA_POOL_PLACEMENT_GROUPS}
         ceph osd pool application enable ${EUCA_CEPH_SNAPSHOT_POOL_NAME} rbd 2>/dev/null || true
+        if [[ "${EUCA_CEPH_MIN_CLIENT:0:1}" > "l" ]]; then
+            ceph mgr module enable pg_autoscaler
+            ceph osd pool set ${EUCA_CEPH_SNAPSHOT_POOL_NAME} pg_autoscale_mode on
+        fi
     fi
 fi
 


### PR DESCRIPTION
With the switch to nautilus, we can now enable the autoscaler by default. More wise ceph users may take the rein and do tune the ceph cluster, but with autoscaler and balancer enabled the ceph cluster should usable in most cases.