### PR TITLE
Remove fixes for Certbot

### DIFF
--- a/roles/cloud-post/tasks/certbot.yml
+++ b/roles/cloud-post/tasks/certbot.yml
@@ -11,12 +11,6 @@
   tags:
     - packages
 
-- name: fix issues with latest CentOS 7
-  yum:
-    name: python-s3transfer.0.1.13-1.el7.0.1
-    allow_downgrade: yes
-    state: present
-
 - name: certbot-renew service.d directory
   file:
     path: /etc/systemd/system/certbot-renew.service.d

--- a/roles/console/tasks/certbot.yml
+++ b/roles/console/tasks/certbot.yml
@@ -11,12 +11,6 @@
   tags:
     - packages
 
-- name: fix issues with latest CentOS 7
-  yum:
-    name: python-s3transfer.0.1.13-1.el7.0.1
-    allow_downgrade: yes
-    state: present
-
 - name: certbot configuration to issue for service endpoints
   set_fact:
     eucaconsole_certbot_domain: "{{ eucaconsole_certbot_domain }},{{ eucaconsole_certbot_services | map('regex_replace', '^(.*)$', '\\1.' + cloud_system_dns_dnsdomain) | list | unique | sort | join(',') }}"


### PR DESCRIPTION
These 'fixes' seems not to work as expexted colliding with ceph installation and other problems. They also seem to be obsolete, at least in few installation cases. We will have to leave it to the user to fix it if they run into problem.